### PR TITLE
Bugs in Zubat BST and Reshiram ROS

### DIFF
--- a/ptcg-server/src/sets/set-battle-styles/zubat.ts
+++ b/ptcg-server/src/sets/set-battle-styles/zubat.ts
@@ -3,7 +3,7 @@ import { Stage, CardType } from '../../game/store/card/card-types';
 import { StoreLike } from '../../game/store/store-like';
 import { State } from '../../game/store/state/state';
 import { Effect } from '../../game/store/effects/effect';
-import { AFTER_ATTACK, SWITCH_ACTIVE_WITH_BENCHED, WAS_ATTACK_USED } from '../../game/store/prefabs/prefabs';
+import { SWITCH_ACTIVE_WITH_BENCHED, WAS_ATTACK_USED } from '../../game/store/prefabs/prefabs';
 
 export class Zubat extends PokemonCard {
 
@@ -38,14 +38,9 @@ export class Zubat extends PokemonCard {
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
 
     if (WAS_ATTACK_USED(effect, 0, this)) {
-      this.usedHideInShadows = true;
+      SWITCH_ACTIVE_WITH_BENCHED(store, state, effect.player);
     }
 
-    if (AFTER_ATTACK(effect) && this.usedHideInShadows) {
-      const player = effect.player;
-      SWITCH_ACTIVE_WITH_BENCHED(store, state, player);
-      this.usedHideInShadows = false;
-    }
     return state;
   }
 }


### PR DESCRIPTION
These two cards had bugs, the Zubat was not switching with a Pokémon from the bench, and the Reshiram was allowing the ability to be used only once per match.