### PR TITLE
Gholdengo SSP 131

### DIFF
--- a/ptcg-server/src/sets/set-surging-sparks/gholdengo.ts
+++ b/ptcg-server/src/sets/set-surging-sparks/gholdengo.ts
@@ -1,0 +1,68 @@
+import { PokemonCard } from '../../game/store/card/pokemon-card';
+import { Stage, CardType } from '../../game/store/card/card-types';
+import { StoreLike, State, PokemonCardList, StateUtils, Resistance, ConfirmPrompt, GameMessage, ShuffleDeckPrompt } from '../../game';
+import { Effect } from '../../game/store/effects/effect';
+import { AttackEffect } from '../../game/store/effects/game-effects';
+
+export class Gholdengo extends PokemonCard {
+  public stage: Stage = Stage.STAGE_1;
+  public cardType: CardType = CardType.METAL;
+  public hp: number = 130;
+  public weakness = [{ type: CardType.FIRE }];
+  public resistance: Resistance[] = [{ type: CardType.GRASS, value: -30 }];
+  public retreat = [CardType.COLORLESS, CardType.COLORLESS];
+  public evolvesFrom = 'Gimmighoul';
+
+  public attacks = [{
+    name: 'Strike It Rich',
+    cost: [CardType.METAL],
+    damage: 30,
+    damageCalculation: '+',
+    text: 'If this Pokémon evolved from Gimmighoul during this turn, this attack does 90 more damage.'
+  },
+  {
+    name: 'Surf Back',
+    cost: [CardType.COLORLESS, CardType.COLORLESS, CardType.COLORLESS],
+    damage: 100,
+    text: 'You may shuffle this Pokémon and all attached cards into your deck.'
+  }];
+
+  public set: string = 'SSP';
+  public regulationMark = 'H';
+  public cardImage: string = 'assets/cardback.png';
+  public fullName: string = 'Gholdengo SSP';
+  public name: string = 'Gholdengo';
+  public setNumber: string = '131';
+
+
+  public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
+    // From Lokix PAL 21
+    if (effect instanceof AttackEffect && effect.attack === this.attacks[0]) {
+      const cardList = StateUtils.findCardList(state, this);
+
+      if (cardList instanceof PokemonCardList) {
+        if (cardList.pokemonPlayedTurn === state.turn) {
+          effect.damage += 90;
+        }
+      }
+      //From Mew V FST
+    } else if (effect instanceof AttackEffect && effect.attack === this.attacks[1]) {
+      const player = effect.player;
+      return store.prompt(state, new ConfirmPrompt(player.id, GameMessage.WANT_TO_USE_ABILITY), wantToUse => {
+        if (wantToUse) {
+          player.active.moveTo(player.deck);
+          player.active.clearEffects();
+          return store.prompt(state, new ShuffleDeckPrompt(player.id), order => {
+            player.deck.applyOrder(order);
+            return state;
+          });
+        }
+        else {
+          return state;
+        }
+      });
+    }
+
+    return state;
+  }
+}

--- a/ptcg-server/src/sets/set-surging-sparks/index.ts
+++ b/ptcg-server/src/sets/set-surging-sparks/index.ts
@@ -5,7 +5,7 @@ import { AlolanDugtrio } from './alolan-dugtrio';
 import { AlolanExeggutorex } from './alolan-exeggutor-ex';
 import { AmuletofHope } from './amulet-of-hope';
 import { Archaludonex } from './archaludon-ex';
-import {Armarouge} from './armarouge';
+import { Armarouge } from './armarouge';
 import { Azelf } from './azelf';
 import { Azumarill } from './azulmarill';
 import { BlackKyuremex } from './black-kyurem-ex';
@@ -16,8 +16,8 @@ import { CelebrationFanfare } from './celebration-fanfare';
 import { Centiskorch } from './centiskorch';
 import { Ceruledge } from './ceruledge';
 import { Ceruledgeex } from './ceruledge-ex';
-import {Cetitan} from './cetitan';
-import {Cetoddle} from './cetoddle';
+import { Cetitan } from './cetitan';
+import { Cetoddle } from './cetoddle';
 import { Charcadet } from './charcadet';
 import { CherishCarrier } from './cherish-carrier';
 import { ChienPao } from './chien-pao';
@@ -45,6 +45,7 @@ import { Flygonex } from './flygon-ex';
 import { Fuecoco } from './fuecoco';
 import { ArchaludonexFA, ArchaludonexSIR, CounterGainUR, CyranoFA, FeebasIR, HydreigonexFA, HydreigonexSIR, JetEnergyUR, LarvestaIR, LatiasexFA, LatiasexSIR, LisiasAppealFA, LisiasAppealSIR, MiloticexFA, MiloticexSIR, NightStretcherUR, PikachuexFA, PikachuexSIR, PikachuexUR, SurferFA } from './full-art';
 import { Gimmighoul } from './gimmighoul';
+import { Gholdengo } from './gholdengo';
 import { GougingFire } from './gouging-fire';
 import { GravityMountain } from './gravity-mountain';
 import { HelperBell } from './helper.bell';
@@ -79,7 +80,7 @@ import { Quaxwell } from './quaxwell';
 import { Rabsca } from './rabsca';
 import { Rellor } from './rellor';
 import { RichEnergy } from './rich-energy';
-import {Rotom} from './rotom';
+import { Rotom } from './rotom';
 import { Sandygast } from './sandygast';
 import { Scovillainex } from './scovillain-ex';
 import { Shroodle } from './shroodle';
@@ -181,6 +182,7 @@ export const setSurgingSparks: Card[] = [
   new ChienPao(),
   new DuskBall(),
   new Gimmighoul(),
+  new Gholdengo(),
   new EnergySearchPro(),
   new Surfer(),
   new GougingFire(),


### PR DESCRIPTION
stage: 1
evolvesFrom: Gimmighoul

cardType: metal
hp: 130
weakness: fire
resistance: -30 grass
retreat: 2

attacks
{M} → Strike It Rich : 30+
If this Pokémon evolved from Gimmighoul during this turn, this attack does 90 more damage.
**Copied from Lokix PAL 21 Assaulting Kick**

{C}{C}{C} → Surf Back : 100
You may shuffle this Pokémon and all attached cards into your deck.
**Copied from Mew V FST Psychic Leap**

regulationMark: "H"
set: SSP
setNumber: 131
cardImage: assets/cardback.png
name: Gholdengo
fullName: Gholdengo SSP

https://github.com/user-attachments/assets/49c1b054-14ad-4a23-b06e-641b45ba9007


