### PR TITLE
Include Call of Legends set

### DIFF
--- a/ptcg-server/output/sets/index.d.ts
+++ b/ptcg-server/output/sets/index.d.ts
@@ -25,6 +25,7 @@ export * from './set-l-p-promos';
 export * from './set-triumphant';
 export * from './set-undaunted';
 export * from './set-unleashed';
+export * from './set-call-of-legends';
 export * from './set-black-and-white-promos';
 export * from './set-black-and-white';
 export * from './set-boundaries-crossed';

--- a/ptcg-server/output/sets/index.js
+++ b/ptcg-server/output/sets/index.js
@@ -42,6 +42,7 @@ __exportStar(require("./set-l-p-promos"), exports);
 __exportStar(require("./set-triumphant"), exports);
 __exportStar(require("./set-undaunted"), exports);
 __exportStar(require("./set-unleashed"), exports);
+__exportStar(require("./set-call-of-legends"), exports);
 //BW Era
 __exportStar(require("./set-black-and-white-promos"), exports);
 __exportStar(require("./set-black-and-white"), exports);

--- a/ptcg-server/src/sets/index.ts
+++ b/ptcg-server/src/sets/index.ts
@@ -36,6 +36,7 @@ export * from './set-l-p-promos';
 export * from './set-triumphant';
 export * from './set-undaunted';
 export * from './set-unleashed';
+export * from './set-call-of-legends';
 
 //BW Era
 export * from './set-black-and-white-promos';

--- a/ptcg-server/start.js
+++ b/ptcg-server/start.js
@@ -46,6 +46,7 @@ cardManager.defineSet(sets.setLPPromos);
 cardManager.defineSet(sets.setTriumphant);
 cardManager.defineSet(sets.setUndaunted);
 cardManager.defineSet(sets.setUnleashed);
+cardManager.defineSet(sets.setCallOfLegends);
 
 cardManager.defineSet(sets.setBlackAndWhitePromos);
 cardManager.defineSet(sets.setBlackAndWhite);


### PR DESCRIPTION
I was taking a look at the repo, and when trying to add some cards noticed that Call of Legends was not being exported. Not a huge deal right now since only Relicanth is in there, but figured it would make sense to have it live since someone took the time to implement it.

On `npm run compile` I noticed that some `dist` files had been updated for unrelated changes. I'm assuming those are only committed for deployments, so I left them out of this PR.