### PR TITLE
Fix Fezandipiti ex Flip the script

### DIFF
--- a/ptcg-server/output/sets/set-shrouded-fable/fezandipiti-ex.d.ts
+++ b/ptcg-server/output/sets/set-shrouded-fable/fezandipiti-ex.d.ts
@@ -31,6 +31,6 @@ export declare class Fezandipitiex extends PokemonCard {
     setNumber: string;
     name: string;
     fullName: string;
-    readonly TABLE_TURNER_MARKER = "TABLE_TURNER_MARKER";
+    readonly OPPONENT_KNOCKOUT_MARKER = "OPPONENT_KNOCKOUT_MARKER";
     reduceEffect(store: StoreLike, state: State, effect: Effect): State;
 }

--- a/ptcg-server/output/sets/set-shrouded-fable/fezandipiti-ex.js
+++ b/ptcg-server/output/sets/set-shrouded-fable/fezandipiti-ex.js
@@ -35,12 +35,12 @@ class Fezandipitiex extends pokemon_card_1.PokemonCard {
         this.setNumber = '38';
         this.name = 'Fezandipiti ex';
         this.fullName = 'Fezandipiti ex SFA';
-        this.TABLE_TURNER_MARKER = 'TABLE_TURNER_MARKER';
+        this.OPPONENT_KNOCKOUT_MARKER = 'OPPONENT_KNOCKOUT_MARKER';
     }
     reduceEffect(store, state, effect) {
         if (effect instanceof game_effects_1.PowerEffect && effect.power === this.powers[0]) {
             const player = effect.player;
-            if (!player.marker.hasMarker('OPPONENT_KNOCKOUT_MARKER')) {
+            if (!player.marker.hasMarker(this.OPPONENT_KNOCKOUT_MARKER)) {
                 throw new game_1.GameError(game_1.GameMessage.CANNOT_USE_POWER);
             }
             if (player.usedTableTurner == true) {
@@ -59,15 +59,18 @@ class Fezandipitiex extends pokemon_card_1.PokemonCard {
         }
         if (effect instanceof game_effects_1.KnockOutEffect) {
             const player = effect.player;
-            const opponent = game_1.StateUtils.getOpponent(state, player);
-            // Do not activate between turns, or when it's not opponents turn.
-            if (state.phase !== state_1.GamePhase.ATTACK || state.players[state.activePlayer] !== opponent) {
+            // Do not activate when it is player's turn
+            if (state.players[state.activePlayer] === player) {
+                return state;
+            }
+            // Do not activate between turns
+            if (state.phase !== state_1.GamePhase.PLAYER_TURN && state.phase !== state_1.GamePhase.ATTACK) {
                 return state;
             }
             const cardList = game_1.StateUtils.findCardList(state, this);
             const owner = game_1.StateUtils.findOwner(state, cardList);
             if (owner === player) {
-                effect.player.marker.addMarkerToState('OPPONENT_KNOCKOUT_MARKER');
+                effect.player.marker.addMarkerToState(this.OPPONENT_KNOCKOUT_MARKER);
             }
             return state;
         }
@@ -76,7 +79,7 @@ class Fezandipitiex extends pokemon_card_1.PokemonCard {
             const cardList = game_1.StateUtils.findCardList(state, this);
             const owner = game_1.StateUtils.findOwner(state, cardList);
             if (owner === player) {
-                effect.player.marker.removeMarker('OPPONENT_KNOCKOUT_MARKER');
+                effect.player.marker.removeMarker(this.OPPONENT_KNOCKOUT_MARKER);
             }
             player.usedTableTurner = false;
         }

--- a/ptcg-server/src/sets/set-shrouded-fable/fezandipiti-ex.ts
+++ b/ptcg-server/src/sets/set-shrouded-fable/fezandipiti-ex.ts
@@ -48,14 +48,14 @@ export class Fezandipitiex extends PokemonCard {
 
   public fullName: string = 'Fezandipiti ex SFA';
 
-  public readonly TABLE_TURNER_MARKER = 'TABLE_TURNER_MARKER';
+  public readonly OPPONENT_KNOCKOUT_MARKER = 'OPPONENT_KNOCKOUT_MARKER';
 
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
 
     if (effect instanceof PowerEffect && effect.power === this.powers[0]) {
       const player = effect.player;
 
-      if (!player.marker.hasMarker('OPPONENT_KNOCKOUT_MARKER')) {
+      if (!player.marker.hasMarker(this.OPPONENT_KNOCKOUT_MARKER)) {
         throw new GameError(GameMessage.CANNOT_USE_POWER);
       }
 
@@ -79,17 +79,20 @@ export class Fezandipitiex extends PokemonCard {
 
     if (effect instanceof KnockOutEffect) {
       const player = effect.player;
-      const opponent = StateUtils.getOpponent(state, player);
 
-      // Do not activate between turns, or when it's not opponents turn.
-      if (state.phase !== GamePhase.ATTACK || state.players[state.activePlayer] !== opponent) {
+      // Do not activate when it is player's turn
+      if (state.players[state.activePlayer] === player) {
+        return state;
+      }
+      // Do not activate between turns
+      if (state.phase !== GamePhase.PLAYER_TURN && state.phase !== GamePhase.ATTACK) {
         return state;
       }
 
       const cardList = StateUtils.findCardList(state, this);
       const owner = StateUtils.findOwner(state, cardList);
       if (owner === player) {
-        effect.player.marker.addMarkerToState('OPPONENT_KNOCKOUT_MARKER');
+        effect.player.marker.addMarkerToState(this.OPPONENT_KNOCKOUT_MARKER);
       }
       return state;
     }
@@ -100,7 +103,7 @@ export class Fezandipitiex extends PokemonCard {
       const owner = StateUtils.findOwner(state, cardList);
 
       if (owner === player) {
-        effect.player.marker.removeMarker('OPPONENT_KNOCKOUT_MARKER');
+        effect.player.marker.removeMarker(this.OPPONENT_KNOCKOUT_MARKER);
       }
       player.usedTableTurner = false;
     }


### PR DESCRIPTION
OPPONENT_KNOCKOUT_MARKER is now set when a pokemon is KO'd during the turn of the opponent and not only when a pokemon is KO'd because of an attack.

![fezandipitiWorks](https://github.com/user-attachments/assets/73b1b2ad-7559-4aff-8078-beab98585a3e)