### PR TITLE
Update Garbodor DRX/LTR/BKP, Wobbuffet PHF, Lillie's Clefairy ex JTG, Stealthy Hood UNB, Fusion Strike Energy FST

### DIFF
--- a/ptcg-server/output/sets/set-breakpoint/garbodor.js
+++ b/ptcg-server/output/sets/set-breakpoint/garbodor.js
@@ -10,6 +10,7 @@ const play_card_action_1 = require("../../game/store/actions/play-card-action");
 const game_error_1 = require("../../game/game-error");
 const game_message_1 = require("../../game/game-message");
 const prefabs_1 = require("../../game/store/prefabs/prefabs");
+const game_1 = require("../../game");
 class Garbodor extends pokemon_card_1.PokemonCard {
     constructor() {
         super(...arguments);
@@ -42,18 +43,19 @@ class Garbodor extends pokemon_card_1.PokemonCard {
             && effect.power.name !== 'Garbotoxin') {
             const player = effect.player;
             const opponent = state_utils_1.StateUtils.getOpponent(state, player);
-            let isGarbodorWithToolInPlay = false;
+            let playerHasGarbotoxin = false;
+            let opponentHasGarbotoxin = false;
             player.forEachPokemon(play_card_action_1.PlayerType.BOTTOM_PLAYER, (cardList, card) => {
                 if (card === this && cardList.tool !== undefined) {
-                    isGarbodorWithToolInPlay = true;
+                    playerHasGarbotoxin = true;
                 }
             });
             opponent.forEachPokemon(play_card_action_1.PlayerType.TOP_PLAYER, (cardList, card) => {
                 if (card === this && cardList.tool !== undefined) {
-                    isGarbodorWithToolInPlay = true;
+                    opponentHasGarbotoxin = true;
                 }
             });
-            if (!isGarbodorWithToolInPlay) {
+            if (!playerHasGarbotoxin && !opponentHasGarbotoxin) {
                 return state;
             }
             // Try reducing ability for each player  
@@ -64,6 +66,16 @@ class Garbodor extends pokemon_card_1.PokemonCard {
             catch (_a) {
                 return state;
             }
+            // Check if we can apply the Ability lock to target Pokemon
+            const cardList = state_utils_1.StateUtils.findCardList(state, effect.card);
+            if (cardList instanceof game_1.PokemonCardList) {
+                const canApplyAbility = new game_effects_1.EffectOfAbilityEffect(playerHasGarbotoxin ? player : opponent, this.powers[0], this, [cardList]);
+                store.reduceEffect(state, canApplyAbility);
+                if (!canApplyAbility.target) {
+                    return state;
+                }
+            }
+            // Apply Ability lock
             if (!effect.power.exemptFromAbilityLock) {
                 throw new game_error_1.GameError(game_message_1.GameMessage.BLOCKED_BY_ABILITY);
             }

--- a/ptcg-server/output/sets/set-dragons-exalted/garbodor.js
+++ b/ptcg-server/output/sets/set-dragons-exalted/garbodor.js
@@ -9,6 +9,7 @@ const state_utils_1 = require("../../game/store/state-utils");
 const play_card_action_1 = require("../../game/store/actions/play-card-action");
 const game_error_1 = require("../../game/game-error");
 const game_message_1 = require("../../game/game-message");
+const game_1 = require("../../game");
 class Garbodor extends pokemon_card_1.PokemonCard {
     constructor() {
         super(...arguments);
@@ -43,18 +44,19 @@ class Garbodor extends pokemon_card_1.PokemonCard {
             && effect.power.name !== 'Garbotoxin') {
             const player = effect.player;
             const opponent = state_utils_1.StateUtils.getOpponent(state, player);
-            let isGarbodorWithToolInPlay = false;
+            let playerHasGarbotoxin = false;
+            let opponentHasGarbotoxin = false;
             player.forEachPokemon(play_card_action_1.PlayerType.BOTTOM_PLAYER, (cardList, card) => {
                 if (card === this && cardList.tool !== undefined) {
-                    isGarbodorWithToolInPlay = true;
+                    playerHasGarbotoxin = true;
                 }
             });
             opponent.forEachPokemon(play_card_action_1.PlayerType.TOP_PLAYER, (cardList, card) => {
                 if (card === this && cardList.tool !== undefined) {
-                    isGarbodorWithToolInPlay = true;
+                    opponentHasGarbotoxin = true;
                 }
             });
-            if (!isGarbodorWithToolInPlay) {
+            if (!playerHasGarbotoxin && !opponentHasGarbotoxin) {
                 return state;
             }
             // Try reducing ability for each player  
@@ -65,6 +67,16 @@ class Garbodor extends pokemon_card_1.PokemonCard {
             catch (_a) {
                 return state;
             }
+            // Check if we can apply the Ability lock to target Pokemon
+            const cardList = state_utils_1.StateUtils.findCardList(state, effect.card);
+            if (cardList instanceof game_1.PokemonCardList) {
+                const canApplyAbility = new game_effects_1.EffectOfAbilityEffect(playerHasGarbotoxin ? player : opponent, this.powers[0], this, [cardList]);
+                store.reduceEffect(state, canApplyAbility);
+                if (!canApplyAbility.target) {
+                    return state;
+                }
+            }
+            // Apply Ability lock
             if (!effect.power.exemptFromAbilityLock) {
                 throw new game_error_1.GameError(game_message_1.GameMessage.BLOCKED_BY_ABILITY);
             }

--- a/ptcg-server/output/sets/set-fusion-strike/fusion-strike-energy.js
+++ b/ptcg-server/output/sets/set-fusion-strike/fusion-strike-energy.js
@@ -24,7 +24,7 @@ class FusionStrikeEnergy extends energy_card_1.EnergyCard {
             'As long as this card is attached to a Pokémon, it provides every type of Energy but provides only 1 Energy at a time. Prevent all effects of your opponent\'s Pokémon\'s Abilities done to the Pokémon this card is attached to.';
     }
     reduceEffect(store, state, effect) {
-        var _a, _b;
+        var _a;
         // Provide energy when attached to Fusion Strike Pokemon
         if (effect instanceof check_effects_1.CheckProvidedEnergyEffect && effect.source.cards.includes(this)) {
             const pokemon = effect.source;
@@ -33,8 +33,13 @@ class FusionStrikeEnergy extends energy_card_1.EnergyCard {
             }
             return state;
         }
-        if (effect instanceof game_effects_1.EffectOfAbilityEffect && ((_b = effect.target) === null || _b === void 0 ? void 0 : _b.cards.includes(this))) {
-            effect.target = undefined;
+        // Prevent effects of abilities from opponent's Pokemon
+        if (effect instanceof game_effects_1.EffectOfAbilityEffect && effect.target) {
+            const opponent = game_1.StateUtils.getOpponent(state, effect.player);
+            // Check for Fusion Strike Energy on the opposing side from the player using the ability
+            if (opponent.getPokemonInPlay().includes(effect.target) && effect.target.cards.includes(this)) {
+                effect.target = undefined;
+            }
         }
         // Discard card when not attached to Fusion Strike Pokemon
         if (effect instanceof play_card_effects_1.AttachEnergyEffect) {

--- a/ptcg-server/output/sets/set-journey-together/lillies-clefairy-ex.d.ts
+++ b/ptcg-server/output/sets/set-journey-together/lillies-clefairy-ex.d.ts
@@ -29,6 +29,5 @@ export declare class LilliesClefairyex extends PokemonCard {
     cardImage: string;
     name: string;
     fullName: string;
-    readonly DRAGON_VULNERABILITY_MARKER = "DRAGON_VULNERABILITY_MARKER";
     reduceEffect(store: StoreLike, state: State, effect: Effect): State;
 }

--- a/ptcg-server/output/sets/set-journey-together/lillies-clefairy-ex.js
+++ b/ptcg-server/output/sets/set-journey-together/lillies-clefairy-ex.js
@@ -6,7 +6,6 @@ const card_types_1 = require("../../game/store/card/card-types");
 const game_1 = require("../../game");
 const game_effects_1 = require("../../game/store/effects/game-effects");
 const check_effects_1 = require("../../game/store/effects/check-effects");
-const prefabs_1 = require("../../game/store/prefabs/prefabs");
 class LilliesClefairyex extends pokemon_card_1.PokemonCard {
     constructor() {
         super(...arguments);
@@ -36,34 +35,33 @@ class LilliesClefairyex extends pokemon_card_1.PokemonCard {
         this.cardImage = 'assets/cardback.png';
         this.name = 'Lillie\'s Clefairy ex';
         this.fullName = 'Lillie\'s Clefairy ex JTG';
-        this.DRAGON_VULNERABILITY_MARKER = 'DRAGON_VULNERABILITY_MARKER';
     }
     reduceEffect(store, state, effect) {
         var _a;
+        // Fairy Zone
         if (effect instanceof check_effects_1.CheckPokemonStatsEffect) {
-            const player = state.players[state.activePlayer];
+            const player = game_1.StateUtils.findOwner(state, effect.target);
             const opponent = game_1.StateUtils.getOpponent(state, player);
             const pokemonCard = effect.target;
+            // Check for opponent's Lillie's Clefairy ex
             let isClefairyexInPlay = false;
-            player.forEachPokemon(game_1.PlayerType.BOTTOM_PLAYER, (cardList, card) => {
-                if (card === this) {
-                    isClefairyexInPlay = true;
-                }
-            });
             opponent.forEachPokemon(game_1.PlayerType.TOP_PLAYER, (cardList, card) => {
                 if (card === this) {
                     isClefairyexInPlay = true;
                 }
             });
-            if (!isClefairyexInPlay) {
+            // Return if no Clefairy or target is not Dragon type
+            if (!isClefairyexInPlay || ((_a = pokemonCard.getPokemonCard()) === null || _a === void 0 ? void 0 : _a.cardType) !== card_types_1.CardType.DRAGON) {
                 return state;
             }
-            if (!prefabs_1.IS_ABILITY_BLOCKED(store, state, player, this)) {
-                if (((_a = pokemonCard.getPokemonCard()) === null || _a === void 0 ? void 0 : _a.cardType) === card_types_1.CardType.DRAGON) {
-                    effect.weakness.push({ type: card_types_1.CardType.PSYCHIC });
-                }
+            // Check if weakness can be changed
+            const canApplyAbility = new game_effects_1.EffectOfAbilityEffect(opponent, this.powers[0], this, [pokemonCard]);
+            store.reduceEffect(state, canApplyAbility);
+            if (canApplyAbility.target) {
+                effect.weakness = [{ type: card_types_1.CardType.PSYCHIC }];
             }
         }
+        // Full Moon Rondo
         if (effect instanceof game_effects_1.AttackEffect && effect.attack === this.attacks[0]) {
             const player = effect.player;
             const opponent = game_1.StateUtils.getOpponent(state, player);

--- a/ptcg-server/output/sets/set-phantom-forces/wobbuffet.js
+++ b/ptcg-server/output/sets/set-phantom-forces/wobbuffet.js
@@ -47,8 +47,9 @@ class Wobbuffet extends pokemon_card_1.PokemonCard {
             const player = effect.player;
             const opponent = state_utils_1.StateUtils.getOpponent(state, player);
             // Wobbuffet is not active Pokemon
-            if (player.active.getPokemonCard() !== this
-                && opponent.active.getPokemonCard() !== this) {
+            const playerHasWobb = player.active.getPokemonCard() === this;
+            const opponentHasWobb = opponent.active.getPokemonCard() === this;
+            if (!playerHasWobb && !opponentHasWobb) {
                 return state;
             }
             let cardTypes = [effect.card.cardType];
@@ -70,6 +71,15 @@ class Wobbuffet extends pokemon_card_1.PokemonCard {
             catch (_a) {
                 return state;
             }
+            // Check if we can apply the Ability lock to target Pokemon
+            if (cardList instanceof pokemon_card_list_1.PokemonCardList) {
+                const canApplyAbility = new game_effects_1.EffectOfAbilityEffect(playerHasWobb ? player : opponent, this.powers[0], this, [cardList]);
+                store.reduceEffect(state, canApplyAbility);
+                if (!canApplyAbility.target) {
+                    return state;
+                }
+            }
+            // Apply Ability lock
             if (!effect.power.exemptFromAbilityLock) {
                 throw new game_error_1.GameError(game_message_1.GameMessage.BLOCKED_BY_ABILITY);
             }

--- a/ptcg-server/output/sets/set-unbroken-bonds/stealthy-hood.d.ts
+++ b/ptcg-server/output/sets/set-unbroken-bonds/stealthy-hood.d.ts
@@ -9,5 +9,6 @@ export declare class StealthyHood extends TrainerCard {
     set: string;
     setNumber: string;
     cardImage: string;
+    text: string;
     reduceEffect(store: StoreLike, state: State, effect: Effect): State;
 }

--- a/ptcg-server/output/sets/set-unbroken-bonds/stealthy-hood.js
+++ b/ptcg-server/output/sets/set-unbroken-bonds/stealthy-hood.js
@@ -3,7 +3,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.StealthyHood = void 0;
 const trainer_card_1 = require("../../game/store/card/trainer-card");
 const card_types_1 = require("../../game/store/card/card-types");
+const game_1 = require("../../game");
 const game_effects_1 = require("../../game/store/effects/game-effects");
+const prefabs_1 = require("../../game/store/prefabs/prefabs");
 class StealthyHood extends trainer_card_1.TrainerCard {
     constructor() {
         super(...arguments);
@@ -13,11 +15,19 @@ class StealthyHood extends trainer_card_1.TrainerCard {
         this.set = 'UNB';
         this.setNumber = '186';
         this.cardImage = 'assets/cardback.png';
+        this.text = 'Prevent all effects of your opponent\'s Abilities done to the Pokémon this card is attached to. Remove any such existing effects.';
     }
     reduceEffect(store, state, effect) {
-        // If this is an ability effect from the opponent
-        if (effect instanceof game_effects_1.EffectOfAbilityEffect && effect.target && effect.target.cards.includes(this)) {
-            effect.target = undefined;
+        // Prevent effects of abilities from opponent's Pokemon
+        if (effect instanceof game_effects_1.EffectOfAbilityEffect && effect.target) {
+            const opponent = game_1.StateUtils.getOpponent(state, effect.player);
+            if (prefabs_1.IS_TOOL_BLOCKED(store, state, opponent, this)) {
+                return state;
+            }
+            // Check for Stealthy Hood on the opposing side from the player using the ability
+            if (opponent.getPokemonInPlay().includes(effect.target) && effect.target.cards.includes(this)) {
+                effect.target = undefined;
+            }
         }
         return state;
     }

--- a/ptcg-server/src/sets/set-breakpoint/garbodor.ts
+++ b/ptcg-server/src/sets/set-breakpoint/garbodor.ts
@@ -3,13 +3,14 @@ import { Stage, CardType } from '../../game/store/card/card-types';
 import { StoreLike } from '../../game/store/store-like';
 import { State } from '../../game/store/state/state';
 import { Effect } from '../../game/store/effects/effect';
-import { PowerEffect } from '../../game/store/effects/game-effects';
+import { EffectOfAbilityEffect, PowerEffect } from '../../game/store/effects/game-effects';
 import { PowerType } from '../../game/store/card/pokemon-types';
 import { StateUtils } from '../../game/store/state-utils';
 import { PlayerType } from '../../game/store/actions/play-card-action';
 import { GameError } from '../../game/game-error';
 import { GameMessage } from '../../game/game-message';
 import { ADD_CONFUSION_TO_PLAYER_ACTIVE, ADD_POISON_TO_PLAYER_ACTIVE, WAS_ATTACK_USED } from '../../game/store/prefabs/prefabs';
+import { PokemonCardList } from '../../game';
 
 export class Garbodor extends PokemonCard {
   public stage: Stage = Stage.STAGE_1;
@@ -46,19 +47,20 @@ export class Garbodor extends PokemonCard {
       const player = effect.player;
       const opponent = StateUtils.getOpponent(state, player);
 
-      let isGarbodorWithToolInPlay = false;
+      let playerHasGarbotoxin = false;
+      let opponentHasGarbotoxin = false;
       player.forEachPokemon(PlayerType.BOTTOM_PLAYER, (cardList, card) => {
         if (card === this && cardList.tool !== undefined) {
-          isGarbodorWithToolInPlay = true;
+          playerHasGarbotoxin = true;
         }
       });
       opponent.forEachPokemon(PlayerType.TOP_PLAYER, (cardList, card) => {
         if (card === this && cardList.tool !== undefined) {
-          isGarbodorWithToolInPlay = true;
+          opponentHasGarbotoxin = true;
         }
       });
 
-      if (!isGarbodorWithToolInPlay) {
+      if (!playerHasGarbotoxin && !opponentHasGarbotoxin) {
         return state;
       }
 
@@ -69,6 +71,18 @@ export class Garbodor extends PokemonCard {
       } catch {
         return state;
       }
+
+      // Check if we can apply the Ability lock to target Pokemon
+      const cardList = StateUtils.findCardList(state, effect.card);
+      if (cardList instanceof PokemonCardList) {
+        const canApplyAbility = new EffectOfAbilityEffect(playerHasGarbotoxin ? player : opponent, this.powers[0], this, [cardList]);
+        store.reduceEffect(state, canApplyAbility);
+        if (!canApplyAbility.target) {
+          return state;
+        }
+      }
+
+      // Apply Ability lock
       if (!effect.power.exemptFromAbilityLock) {
         throw new GameError(GameMessage.BLOCKED_BY_ABILITY);
       }

--- a/ptcg-server/src/sets/set-fusion-strike/fusion-strike-energy.ts
+++ b/ptcg-server/src/sets/set-fusion-strike/fusion-strike-energy.ts
@@ -1,4 +1,4 @@
-import { PlayerType, State, StoreLike } from '../../game';
+import { PlayerType, State, StateUtils, StoreLike } from '../../game';
 import { CardTag, CardType, EnergyType } from '../../game/store/card/card-types';
 import { EnergyCard } from '../../game/store/card/energy-card';
 import { CheckProvidedEnergyEffect } from '../../game/store/effects/check-effects';
@@ -43,8 +43,14 @@ export class FusionStrikeEnergy extends EnergyCard {
       return state;
     }
 
-    if (effect instanceof EffectOfAbilityEffect && effect.target?.cards.includes(this)) {
-      effect.target = undefined;
+    // Prevent effects of abilities from opponent's Pokemon
+    if (effect instanceof EffectOfAbilityEffect && effect.target) {
+      const opponent = StateUtils.getOpponent(state, effect.player);
+
+      // Check for Fusion Strike Energy on the opposing side from the player using the ability
+      if (opponent.getPokemonInPlay().includes(effect.target) && effect.target.cards.includes(this)) {
+        effect.target = undefined;
+      }
     }
 
     // Discard card when not attached to Fusion Strike Pokemon

--- a/ptcg-server/src/sets/set-phantom-forces/wobbuffet.ts
+++ b/ptcg-server/src/sets/set-phantom-forces/wobbuffet.ts
@@ -5,7 +5,7 @@ import { PokemonCard } from '../../game/store/card/pokemon-card';
 import { PowerType } from '../../game/store/card/pokemon-types';
 import { CheckPokemonTypeEffect } from '../../game/store/effects/check-effects';
 import { Effect } from '../../game/store/effects/effect';
-import { AttackEffect, PowerEffect } from '../../game/store/effects/game-effects';
+import { AttackEffect, EffectOfAbilityEffect, PowerEffect } from '../../game/store/effects/game-effects';
 import { StateUtils } from '../../game/store/state-utils';
 import { PokemonCardList } from '../../game/store/state/pokemon-card-list';
 import { State } from '../../game/store/state/state';
@@ -61,8 +61,9 @@ export class Wobbuffet extends PokemonCard {
       const opponent = StateUtils.getOpponent(state, player);
 
       // Wobbuffet is not active Pokemon
-      if (player.active.getPokemonCard() !== this
-        && opponent.active.getPokemonCard() !== this) {
+      const playerHasWobb = player.active.getPokemonCard() === this;
+      const opponentHasWobb = opponent.active.getPokemonCard() === this
+      if (!playerHasWobb && !opponentHasWobb) {
         return state;
       }
 
@@ -87,6 +88,17 @@ export class Wobbuffet extends PokemonCard {
       } catch {
         return state;
       }
+
+      // Check if we can apply the Ability lock to target Pokemon
+      if (cardList instanceof PokemonCardList) {
+        const canApplyAbility = new EffectOfAbilityEffect(playerHasWobb ? player : opponent, this.powers[0], this, [cardList]);
+        store.reduceEffect(state, canApplyAbility);
+        if (!canApplyAbility.target) {
+          return state;
+        }
+      }
+
+      // Apply Ability lock
       if (!effect.power.exemptFromAbilityLock) {
         throw new GameError(GameMessage.BLOCKED_BY_ABILITY);
       }

--- a/ptcg-server/src/sets/set-unbroken-bonds/stealthy-hood.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/stealthy-hood.ts
@@ -1,8 +1,9 @@
 import { TrainerCard } from '../../game/store/card/trainer-card';
 import { TrainerType } from '../../game/store/card/card-types';
-import { StoreLike, State } from '../../game';
+import { StoreLike, State, StateUtils } from '../../game';
 import { Effect } from '../../game/store/effects/effect';
 import { EffectOfAbilityEffect } from '../../game/store/effects/game-effects';
+import { IS_TOOL_BLOCKED } from '../../game/store/prefabs/prefabs';
 
 export class StealthyHood extends TrainerCard {
   public trainerType: TrainerType = TrainerType.TOOL;
@@ -11,11 +12,21 @@ export class StealthyHood extends TrainerCard {
   public set: string = 'UNB';
   public setNumber: string = '186';
   public cardImage: string = 'assets/cardback.png';
+  public text: string = 'Prevent all effects of your opponent\'s Abilities done to the Pokémon this card is attached to. Remove any such existing effects.'
 
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
-    // If this is an ability effect from the opponent
-    if (effect instanceof EffectOfAbilityEffect && effect.target && effect.target.cards.includes(this)) {
-      effect.target = undefined;
+    // Prevent effects of abilities from opponent's Pokemon
+    if (effect instanceof EffectOfAbilityEffect && effect.target) {
+      const opponent = StateUtils.getOpponent(state, effect.player);
+
+      if (IS_TOOL_BLOCKED(store, state, opponent, this)) {
+        return state;
+      }
+
+      // Check for Stealthy Hood on the opposing side from the player using the ability
+      if (opponent.getPokemonInPlay().includes(effect.target) && effect.target.cards.includes(this)) {
+        effect.target = undefined;
+      }
     }
     return state;
   }


### PR DESCRIPTION
+ Update Garbotoxin, Bide Barricade, and Fairy Zone to use EffectOfAbilityEffect
+ Fix Fairy Zone to only affect opponent's Dragon Pokemon
+ Fix Stealthy Hood and Fusion Strike Energy to only prevent effects of Abilities from opponent's Pokemon

https://github.com/user-attachments/assets/2a56f87a-eb33-4403-892a-a3cd4956ec0d

https://github.com/user-attachments/assets/40552dd6-d3e9-40b2-a1da-bb45530e24ad

https://github.com/user-attachments/assets/22a7addc-499b-4eb8-83b1-6a8ce3a852bb

https://github.com/user-attachments/assets/0124d919-1e01-434d-90cb-5147bd84fce7

https://github.com/user-attachments/assets/0709714b-6f15-4e3f-b7d7-a71b51852a61