### PR TITLE
Fix ADP working improperly with extra Energy

### DIFF
--- a/ptcg-server/src/sets/set-cosmic-eclipse/arceus-dialga-palkia-gx.ts
+++ b/ptcg-server/src/sets/set-cosmic-eclipse/arceus-dialga-palkia-gx.ts
@@ -102,7 +102,7 @@ export class ArceusDialgaPalkiaGX extends PokemonCard {
         e.provides.includes(CardType.WATER));
 
       if (hasWaterEnergy) {
-        player.usedAlteredCreation == true;
+        player.usedAlteredCreation = true;
         console.log('Used Altered Creation with Extra Water');
       }
     }


### PR DESCRIPTION
Originally reported on the Twinleaf Discord: https://discord.com/channels/1186678164517290105/1359214801896869979

The root cause is most likely a typo: it should be `=` (assignment), not `==` (equality check).