### PR TITLE
Fix Ralts not being detected as Standard Nightly

### DIFF
--- a/ptcg-server/src/sets/set-m1s/ralts.ts
+++ b/ptcg-server/src/sets/set-m1s/ralts.ts
@@ -31,8 +31,10 @@ export class Ralts extends PokemonCard {
     }
   ];
 
+  public regulationMark = 'I';
   public set: string = 'M1S';
-
+  public setNumber: string = '40';
+  public cardImage: string = 'assets/cardback.png';
   public name: string = 'Ralts';
 
   public fullName: string = 'Ralts M1S';


### PR DESCRIPTION
This card had two bugs, one was it had no image back showing and the other was that the missing regulation mark meant its inclusion made it invalid for Standard Nightly thus could not be used in that format.

This PR fixes both of them.