### PR TITLE
Cleanup base64 handling

### DIFF
--- a/ptcg-server/src/utils/base64.ts
+++ b/ptcg-server/src/utils/base64.ts
@@ -2,15 +2,14 @@ export class Base64 {
   public encode(s: string): string {
     // Encode string as UTF-8 bytes, then base64 encode
     const utf8Bytes = new TextEncoder().encode(s);
-    let binary = '';
-    utf8Bytes.forEach(byte => binary += String.fromCharCode(byte));
+    const binary = Array.from(utf8Bytes, (byte) => String.fromCodePoint(byte)).join("");
     return btoa(binary);
   }
 
   public decode(s: string): string {
     // Decode base64 to bytes, then interpret as UTF-8 string
     const binary = atob(s);
-    const bytes = new Uint8Array([...binary].map(char => char.charCodeAt(0)));
+    const bytes = Uint8Array.from(binary, (b) => b.codePointAt(0))
     return new TextDecoder().decode(bytes);
   }
 }


### PR DESCRIPTION
This uses the codepoint methods instead of the code unit ones to prevent potential issues with surrogate pairs. This also cleans up the functions to return an in-place array instead of mutating.