### PR TITLE
Add an option to sort discard pile

### DIFF
--- a/ptcg-play/src/app/shared/cards/card-info-list-popup/card-info-list-popup.component.html
+++ b/ptcg-play/src/app/shared/cards/card-info-list-popup/card-info-list-popup.component.html
@@ -3,6 +3,13 @@
 </h2>
 
 <mat-dialog-content>
+  <div style="margin-bottom: 10px;">
+    <label>
+      <input type="checkbox" [(ngModel)]="sortDiscards" (change)="onSortDiscardsChange()" />
+      Sort Discard
+    </label>
+  </div>
+
   <ptcg-card-list-pane [selected]="card" [cardList]="cardList" [facedown]="facedown" (cardClick)="showCardInfo($event)">
   </ptcg-card-list-pane>
 </mat-dialog-content>

--- a/ptcg-play/src/app/shared/cards/cards.module.ts
+++ b/ptcg-play/src/app/shared/cards/cards.module.ts
@@ -20,10 +20,12 @@ import { MaterialModule } from '../material.module';
 import { TrainerTypeComponent } from './trainer-type/trainer-type.component';
 import { HoverHighlightComponent } from './hover-highlight/hover-highlight.component';
 import { ArchetypeComponent } from './archetype/archetype.component';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   imports: [
     CommonModule,
+    FormsModule,
     ImageCacheModule,
     MaterialModule,
     DndMultiBackendModule,

--- a/ptcg-play/src/app/table/prompt/prompt-show-cards/prompt-show-cards.component.ts
+++ b/ptcg-play/src/app/table/prompt/prompt-show-cards/prompt-show-cards.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, OnDestroy } from '@angular/core';
-import { ShowCardsPrompt, Card, GamePhase } from 'ptcg-server';
+import { ShowCardsPrompt, Card, GamePhase, SuperType } from 'ptcg-server';
 
 import { CardsBaseService } from '../../../shared/cards/cards-base.service';
 import { GameService } from '../../../api/services/game.service';
@@ -18,6 +18,7 @@ export class PromptShowCardsComponent implements OnInit, OnDestroy {
   @Input() gameState: LocalGameState;
 
   public isLoading = true;
+  public sortDiscards: boolean = false;
 
   private isResolved = false;
   private timeoutId: any;
@@ -36,6 +37,9 @@ export class PromptShowCardsComponent implements OnInit, OnDestroy {
     ).subscribe(() => {
       this.resolvePrompt();
     });
+    if (this.sortDiscards) {
+      this.prompt.cards = this.sortDiscardCards(this.prompt.cards);
+    }
   }
 
   ngOnDestroy() {
@@ -69,5 +73,17 @@ export class PromptShowCardsComponent implements OnInit, OnDestroy {
 
   public onCardClick(card: Card) {
     this.cardsBaseService.showCardInfo({ card });
+  }
+
+  private sortDiscardCards(cards: Card[]): Card[] {
+    const pokemonCards = cards.filter(c => c.superType === SuperType.POKEMON);
+    const trainerCards = cards.filter(c => c.superType === SuperType.TRAINER);
+    const energyCards = cards.filter(c => c.superType === SuperType.ENERGY);
+
+    return [
+      ...pokemonCards,
+      ...trainerCards,
+      ...energyCards
+    ];
   }
 }


### PR DESCRIPTION
Hey ya'll, this is my first contribution to Twinleaf so I would appreciate any feedback!

This PR implements the suggestion "add an option to sort discard pile". 

Since sorting is optional, I’ve preserved the original discard pile order and added a toggle directly in the discard view to switch between unsorted and sorted views.

That said, I’m wondering if we might want to sort the discard pile by default, similar to how the deck is shown when using a search effect. I noticed that deck views are already sorted, so could we leverage the same logic or pattern here for consistency?

I'd love feedback on:
- Code style and structure
- Whether there's a preferred approach to handling sorted/unsorted piles
- Any edge cases in this part of the code I should be aware of

Thank you! 



https://github.com/user-attachments/assets/67f38726-3eca-49fe-ba8e-2d88bb4a74eb



