### PR TITLE
Fix wrongly blocked Pokémon in choose-cards-prompt.ts

### DIFF
--- a/ptcg-server/src/game/store/prompts/choose-cards-prompt.ts
+++ b/ptcg-server/src/game/store/prompts/choose-cards-prompt.ts
@@ -38,7 +38,7 @@ export class ChooseCardsPrompt extends Prompt<Card[]> {
   readonly type: string = ChooseCardsPromptType;
 
   public options: ChooseCardsOptions;
-  private blockedCardNames: string[] = [];
+  private blockedCardIds: number[] = [];
   public player: Player;
 
   constructor(
@@ -75,8 +75,8 @@ export class ChooseCardsPrompt extends Prompt<Card[]> {
     if (this.options.blocked.length > 0) {
       for (let i = 0; i < this.cards.cards.length; i++) {
         if (this.options.blocked.indexOf(i) !== -1) {
-          if (this.blockedCardNames.indexOf(this.cards.cards[i].name) === -1) {
-            this.blockedCardNames.push(this.cards.cards[i].name);
+          if (this.blockedCardIds.indexOf(this.cards.cards[i].id) === -1) {
+            this.blockedCardIds.push(this.cards.cards[i].id);
           }
         }
       }
@@ -91,7 +91,7 @@ export class ChooseCardsPrompt extends Prompt<Card[]> {
     if (this.options.blocked.length > 0) {
       this.options.blocked = [];
       this.cards.cards.forEach((card, index) => {
-        if (this.blockedCardNames.indexOf(card.name) !== -1) {
+        if (this.blockedCardIds.indexOf(card.id) !== -1) {
           this.options.blocked.push(index);
         }
       });


### PR DESCRIPTION
## Context & problem
* When `choose-cards-prompt.ts` is invoked, a "blocked" array can be passed to exclude some cards (e.g. non-basic, non-"PLAY_DURING_SETUP" pokemon for setup, LV.X pokemon for Luxury Ball, etc.) by storing its index value within the location (hand, deck, discard etc.)
* Since the `choose-cards-prompt.ts` constructor wants to sort the cards for better UX (if it's in a non-secret deck or discard pile view), it first needs to re-map the `blocked` property array from index values to something else.
* As of today, this is done with by creating a temporary property that stores all the blocked card names (called `blockedCardNames` 🙃) which is then used to re-build the `blocked` property array with index values after the sort
* This implementation has two major bugs:
  1) LV.X Pokémon and the respective stages they level up from share the exact same name (the "LV.X" is not part of it), so when an Arceus LV.X ends up in a `blocked` argument (for example during set-up, when all non-basic, non-"PLAY_DURING_SETUP" Pokémon are excluded) all "Arceus" cards that come after it won't be selectable.
  2) When using an effect like Brooklet Hill's, if I have two Pokémon in my deck that share the same name but have different types and only one of them is a valid target, this will still result in both being blocked as long as the non-valid one comes before the valid one.

## Proposed solution
* Create a temporary property that stores all the blocked card IDs called `blockedCardIds` (instead of `blockedCardNames`).
* Use the `blockedCardIds` property to re-build the `blocked` property array with index values after the sort.
* This should fix the two bugs mentioned above and anything similar that relies on the `blocked` property array.

## Tests

### Setup
<img width="2559" height="1346" alt="Screenshot 2025-08-09 145317" src="https://github.com/user-attachments/assets/7f5e45cb-0876-4c55-ac32-3efd0327f3e1" />

### Luxury Ball
<img width="2558" height="1348" alt="Screenshot 2025-08-09 150518" src="https://github.com/user-attachments/assets/990f8fd2-b136-4df4-9feb-a2b1ef18cd96" />

### Brooklet Hill
<img width="2559" height="1344" alt="Screenshot 2025-08-09 145804" src="https://github.com/user-attachments/assets/07728f8b-664e-46b7-a4db-409c1d182d7d" />
