### PR TITLE
Hp boost fix

### DIFF
--- a/ptcg-play/src/app/shared/cards/card-info-pane/card-info-pane.component.ts
+++ b/ptcg-play/src/app/shared/cards/card-info-pane/card-info-pane.component.ts
@@ -23,14 +23,13 @@ export interface CardInfoPaneAction {
   cardList?: PokemonCardList;
 }
 
-// Helper type guards for computedHp and hp
-function hasComputedHp(obj: any): obj is { computedHp: number } {
-  return obj && typeof obj.computedHp === 'number';
-}
 function hasHp(obj: any): obj is { hp: number | string } {
   return obj && (typeof obj.hp === 'number' || typeof obj.hp === 'string');
 }
 
+function hasHpBonus(obj: any): obj is { hpBonus: number } {
+  return obj && typeof obj.hpBonus === 'number';
+}
 @Component({
   selector: 'ptcg-card-info-pane',
   templateUrl: './card-info-pane.component.html',
@@ -357,13 +356,14 @@ export class CardInfoPaneComponent implements OnChanges {
   public getComputedHp(): number | null {
     if (!this.card || this.card.superType !== SuperType.POKEMON) return null;
     // Prefer computedHp from cardList, fallback to card.hp
-    if (this.cardList && hasComputedHp(this.cardList)) {
-      return this.cardList.computedHp;
-    }
+    var hp: number = 0;
     if (hasHp(this.card)) {
-      return Number(this.card.hp) || 0;
+      hp = Number(this.card.hp) || 0;
     }
-    return 0;
+    if (hasHpBonus(this.cardList)) {
+      hp += this.cardList.hpBonus || 0;
+    }
+    return hp;
   }
 
   public getCurrentHp(): number | null {

--- a/ptcg-server/src/backend/socket/core-socket.ts
+++ b/ptcg-server/src/backend/socket/core-socket.ts
@@ -9,8 +9,6 @@ import { SocketCache } from './socket-cache';
 import { SocketWrapper, Response } from './socket-wrapper';
 import { deepCompare } from '../../utils/utils';
 import { Base64 } from '../../utils';
-import { CheckHpEffect } from '../../game/store/effects/check-effects';
-import { PokemonCardList } from '../../game/store/state/pokemon-card-list';
 
 export class CoreSocket {
 
@@ -140,33 +138,6 @@ export class CoreSocket {
     const serializer = new StateSerializer();
     const serializedState = serializer.serialize(game.state);
     const stateObj = JSON.parse(serializedState);
-
-    // Inject computedHp for each PokemonCardList (active and bench)
-    const players = game.state.players;
-    const store = game.getStore();
-    for (let p = 0; p < players.length; p++) {
-      const player = players[p];
-      // Active
-      if (player.active instanceof PokemonCardList) {
-        const checkHp = new CheckHpEffect(player, player.active);
-        store.reduceEffect(game.state, checkHp);
-        if (stateObj[0][p].active) {
-          stateObj[0][p].active.computedHp = checkHp.hp;
-        }
-      }
-      // Bench
-      for (let b = 0; b < player.bench.length; b++) {
-        const bench = player.bench[b];
-        if (bench instanceof PokemonCardList) {
-          const checkHp = new CheckHpEffect(player, bench);
-          store.reduceEffect(game.state, checkHp);
-          if (stateObj[0][p].bench && stateObj[0][p].bench[b]) {
-            stateObj[0][p].bench[b].computedHp = checkHp.hp;
-          }
-        }
-      }
-    }
-
     const finalSerializedState = JSON.stringify(stateObj);
     const base64 = new Base64();
     const stateData = base64.encode(finalSerializedState);

--- a/ptcg-server/src/backend/socket/game-socket.ts
+++ b/ptcg-server/src/backend/socket/game-socket.ts
@@ -70,6 +70,7 @@ export class GameSocket {
 
   public onStateChange(game: Game, state: State): void {
     if (this.core.games.indexOf(game) !== -1) {
+      game.setBonusHps(state);
       state = this.stateSanitizer.sanitize(game.state, game.id);
 
       // Emit turn start if active player changed

--- a/ptcg-server/src/game/core/game.ts
+++ b/ptcg-server/src/game/core/game.ts
@@ -11,6 +11,7 @@ import { Store } from '../store/store';
 import { StoreHandler } from '../store/store-handler';
 import { AbortGameAction, AbortGameReason } from '../store/actions/abort-game-action';
 import { Format } from '../store/card/card-types';
+import { CheckHpEffect } from '../store/effects/check-effects';
 import { deepClone } from '../../utils/utils';
 import { logger } from '../../utils/logger';
 
@@ -83,6 +84,21 @@ export class Game implements StoreHandler {
     // Clear disconnected players tracking
     this.disconnectedPlayers.clear();
     this.isPaused = false;
+  }
+
+  public setBonusHps(state: State): void {
+    for (const player of state.players) {
+      if (player.active.getPokemonCard() !== undefined) {
+        const checkHp = new CheckHpEffect(player, player.active);
+        this.store.reduceEffect(state, checkHp);
+      }
+      for (let b = 0; b < player.bench.length; b++) {
+        if (player.bench[b].getPokemonCard() !== undefined) {
+          const checkHp = new CheckHpEffect(player, player.bench[b]);
+          this.store.reduceEffect(state, checkHp);
+        }
+      }
+    }
   }
 
   public onStateChange(state: State): void {

--- a/ptcg-server/src/game/serializer/card-list.serializer.ts
+++ b/ptcg-server/src/game/serializer/card-list.serializer.ts
@@ -58,10 +58,6 @@ export class CardListSerializer implements Serializer<CardList> {
       instance.showBasicAnimation = data.showBasicAnimation || false;
       instance.triggerEvolutionAnimation = data.triggerEvolutionAnimation || false;
       instance.triggerAttackAnimation = data.triggerAttackAnimation || false;
-      // Copy computedHp if present
-      if (typeof data.computedHp === 'number') {
-        (instance as any).computedHp = data.computedHp;
-      }
     }
 
     return Object.assign(instance, data);

--- a/ptcg-server/src/game/store/effects/check-effects.ts
+++ b/ptcg-server/src/game/store/effects/check-effects.ts
@@ -6,6 +6,7 @@ import { Resistance, Weakness, Attack, Power } from '../card/pokemon-types';
 import { EnergyMap } from '../prompts/choose-energy-prompt';
 import { TrainerCard } from '../card/trainer-card';
 import { Card } from '../card/card';
+import { PokemonCard } from '../card/pokemon-card';
 import { CardList } from '../state/card-list';
 
 export enum CheckEffects {
@@ -62,14 +63,25 @@ export class CheckHpEffect implements Effect {
   public preventDefault = false;
   public player: Player;
   public target: PokemonCardList;
-  public hp: number;
+  private pokemonCard: PokemonCard | undefined;
+  public get hp(): number {
+    if (this.pokemonCard === undefined) {
+      return 0;
+    }
+    return this.pokemonCard.hp + this.target.hpBonus;
+  }
+  public set hp(value: number) {
+    if (this.pokemonCard !== undefined) {
+      this.target.hpBonus = value - this.pokemonCard.hp;
+    }
+  }
   public nonstackingBoosts: string[] = [];
 
   constructor(player: Player, target: PokemonCardList) {
     this.player = player;
     this.target = target;
-    const pokemonCard = target.getPokemonCard();
-    this.hp = pokemonCard ? pokemonCard.hp : 0;
+    this.pokemonCard = target.getPokemonCard();
+    this.hp = this.pokemonCard ? this.pokemonCard.hp : 0;
   }
 }
 

--- a/ptcg-server/src/game/store/effects/check-effects.ts
+++ b/ptcg-server/src/game/store/effects/check-effects.ts
@@ -63,7 +63,7 @@ export class CheckHpEffect implements Effect {
   public player: Player;
   public target: PokemonCardList;
   public hp: number;
-  public hpBoosted?: boolean;
+  public nonstackingBoosts: string[] = [];
 
   constructor(player: Player, target: PokemonCardList) {
     this.player = player;

--- a/ptcg-server/src/sets/set-astral-radiance/kricketune.ts
+++ b/ptcg-server/src/sets/set-astral-radiance/kricketune.ts
@@ -49,7 +49,7 @@ export class Kricketune extends PokemonCard {
       }
 
       // If HP boost already applied, skip
-      if (effect.hpBoosted) {
+      if (effect.nonstackingBoosts.includes(this.powers[0].name)) {
         return state;
       }
 
@@ -89,10 +89,8 @@ export class Kricketune extends PokemonCard {
       }
 
       // Finally, if we haven't boosted HP in this CheckHpEffect yet, add +40
-      if (!effect.hpBoosted) {
-        effect.hp += 40;
-        effect.hpBoosted = true;
-      }
+      effect.hp += 40;
+      effect.nonstackingBoosts.push(this.powers[0].name);
     }
 
     return state;

--- a/ptcg-server/src/sets/set-evolving-skies/wishiwashi.ts
+++ b/ptcg-server/src/sets/set-evolving-skies/wishiwashi.ts
@@ -51,7 +51,8 @@ export class Wishiwashi extends PokemonCard {
     if (effect instanceof CheckHpEffect) {
       const player = effect.player;
 
-      if (IS_ABILITY_BLOCKED(store, state, player, this) || effect.hpBoosted) {
+      const targetPokemonCard = effect.target.getPokemonCard();
+      if (IS_ABILITY_BLOCKED(store, state, player, this) || targetPokemonCard !== this) {
         return state;
       }
 
@@ -67,8 +68,7 @@ export class Wishiwashi extends PokemonCard {
       });
 
       if (energyCount >= 3) {
-        effect.hpBoosted = true;
-        this.hp += 150;
+        effect.hp += 150;
       }
     }
 

--- a/ptcg-server/src/sets/set-journey-together/ludicolo.ts
+++ b/ptcg-server/src/sets/set-journey-together/ludicolo.ts
@@ -34,12 +34,12 @@ export class Ludicolo extends PokemonCard {
       const cardList = StateUtils.findCardList(state, this);
       const player = StateUtils.findOwner(state, cardList);
 
-      if (!StateUtils.isPokemonInPlay(player, this) || IS_ABILITY_BLOCKED(store, state, player, this) || effect.hpBoosted) {
+      if (!StateUtils.isPokemonInPlay(player, this) || IS_ABILITY_BLOCKED(store, state, player, this) || effect.nonstackingBoosts.includes(this.powers[0].name)) {
         return state;
       }
 
       effect.hp += 40;
-      effect.hpBoosted = true;
+      effect.nonstackingBoosts.push(this.powers[0].name);
     }
 
     return state;

--- a/ptcg-server/src/sets/set-mysterious-treasures/unown-e.ts
+++ b/ptcg-server/src/sets/set-mysterious-treasures/unown-e.ts
@@ -125,7 +125,6 @@ export class UnownE extends PokemonCard {
 
       if (card.stage === Stage.BASIC) {
         effect.hp += 10;
-        effect.target.hpBonus = (effect.target.hpBonus || 0) + 10;
       }
       return state;
     }

--- a/ptcg-server/src/sets/set-paldea-evolved/bravery-charm.ts
+++ b/ptcg-server/src/sets/set-paldea-evolved/bravery-charm.ts
@@ -35,7 +35,6 @@ export class BraveryCharm extends TrainerCard {
 
       if (card.stage === Stage.BASIC) {
         effect.hp += this.HP_BONUS;
-        effect.target.hpBonus = (effect.target.hpBonus || 0) + this.HP_BONUS;
       }
     }
     return state;


### PR DESCRIPTION
This commit contains a number of bug fixes pertaining to hp boosting
- Fixes inconsistent Wishiwashi behavior from Evolving Skies
- Allows Kricketune ASR and Ludicolo JTG to stack
- Displays boosted HP values correctly

Faulty wishiwashi behavior
https://github.com/user-attachments/assets/b4584bbe-b8ae-4a51-8eb4-b850863d49f2

Failed HP Stacking (using damage counters to KO to show hp value since HP does not show in UI)
https://github.com/user-attachments/assets/ff47c994-c6b1-4e82-abfb-53e24bdc106f

Successfully stacked Kricketune and Ludicolo
<img width="877" height="617" alt="hpstack" src="https://github.com/user-attachments/assets/df3d8661-9a6c-404d-8250-23f3e8b43766" />


