### PR TITLE
Survival fix

### DIFF
--- a/ptcg-play/src/assets/i18n/en.json
+++ b/ptcg-play/src/assets/i18n/en.json
@@ -542,6 +542,7 @@
     "LOG_BANNED_BY_ARBITER": "{{name}} made an invalid move multiple times and was banned by the arbiter.",
     "LOG_FLIP_ASLEEP": "{{name}} flips a coin for Status Condition: Asleep.",
     "LOG_ABILITY_BLOCKS_DAMAGE": "{{ name }} prevents damage with {{ pokemon }}'s ability.",
+    "LOG_SURVIVES_ON_TEN_HP": "{{pokemon}} survives on 10 HP due to the effect of {{reason}}.",
     "LOG_FLIP_CONFUSION": "{{name}} a coin for Status Condition: Confusion.",
     "LOG_GAME_FINISHED": "Game finished.",
     "LOG_GAME_FINISHED_BEFORE_STARTED": "Game finished before it has started.",

--- a/ptcg-server/src/game/game-message.ts
+++ b/ptcg-server/src/game/game-message.ts
@@ -217,6 +217,7 @@ export enum GameCardMessage {
 export enum GameLog {
   LOG_BANNED_BY_ARBITER = 'LOG_BANNED_BY_ARBITER', // { name }
   LOG_ABILITY_BLOCKS_DAMAGE = 'LOG_ABILITY_BLOCKS_DAMAGE', // { name, pokemon }
+  LOG_SURVIVES_ON_TEN_HP = 'LOG_SURVIVES_ON_TEN_HP', // { pokemon, reason }
   LOG_FLIP_ASLEEP = 'LOG_FLIP_ASLEEP', // { name }
   LOG_FLIP_CONFUSION = 'LOG_FLIP_CONFUSION', // { name }
   LOG_GAME_FINISHED = 'LOG_GAME_FINISHED',

--- a/ptcg-server/src/game/store/effect-reducers/attack-effect.ts
+++ b/ptcg-server/src/game/store/effect-reducers/attack-effect.ts
@@ -18,6 +18,7 @@ import { StateUtils } from '../state-utils';
 import { getCardTarget } from '../../../simple-bot/simple-tactics/simple-tactics';
 import { EffectOfAttackEffect } from '../effects/effect-of-attack-effects';
 import { GameStatsTracker } from '../game-stats-tracker';
+import { CheckHpEffect } from '../effects/check-effects';
 
 export function attackReducer(store: StoreLike, state: State, effect: Effect): State {
 
@@ -67,6 +68,18 @@ export function attackReducer(store: StoreLike, state: State, effect: Effect): S
 
       if (targetCard.damageTakenLastTurn !== undefined) {
         targetCard.damageTakenLastTurn += damage;
+      }
+
+      if (effect.surviveOnTenHPReason !== undefined) {
+        const checkHpEffect = new CheckHpEffect(effect.player, target);
+        state = store.reduceEffect(state, checkHpEffect);
+        if (target.damage > checkHpEffect.hp) {
+          store.log(state, GameLog.LOG_SURVIVES_ON_TEN_HP, {
+            pokemon: targetCard.name,
+            reason: effect.surviveOnTenHPReason,
+          });
+          target.damage = checkHpEffect.hp - 10;
+        }
       }
 
       const afterDamageEffect = new AfterDamageEffect(effect.attackEffect, damage);

--- a/ptcg-server/src/game/store/effects/attack-effects.ts
+++ b/ptcg-server/src/game/store/effects/attack-effects.ts
@@ -73,6 +73,7 @@ export class PutDamageEffect extends AbstractAttackEffect implements Effect {
   public damageReduced = false;
   public damageIncreased = true;
   public wasKnockedOutFromFullHP: boolean = false;
+  public surviveOnTenHPReason: undefined | string = undefined;
   public weaknessApplied: boolean = false;
 
   constructor(base: AttackEffect, damage: number) {

--- a/ptcg-server/src/game/store/prefabs/prefabs.ts
+++ b/ptcg-server/src/game/store/prefabs/prefabs.ts
@@ -3,7 +3,7 @@ import { TrainerEffect } from '../effects/play-card-effects';
 import { BoardEffect, CardTag, SpecialCondition, Stage, SuperType } from '../card/card-types';
 import { PokemonCard } from '../card/pokemon-card';
 import { ApplyWeaknessEffect, DealDamageEffect, DiscardCardsEffect, HealTargetEffect, PutDamageEffect } from '../effects/attack-effects';
-import { AddSpecialConditionsPowerEffect, CheckPrizesDestinationEffect, CheckProvidedEnergyEffect } from '../effects/check-effects';
+import { AddSpecialConditionsPowerEffect, CheckHpEffect, CheckPrizesDestinationEffect, CheckProvidedEnergyEffect } from '../effects/check-effects';
 import { Effect } from '../effects/effect';
 import { AttackEffect, DrawPrizesEffect, EvolveEffect, KnockOutEffect, PowerEffect, RetreatEffect, SpecialEnergyEffect } from '../effects/game-effects';
 import { AfterAttackEffect, EndTurnEffect } from '../effects/game-phase-effects';
@@ -1175,6 +1175,19 @@ export function BLOCK_RETREAT(store: StoreLike, state: State, effect: AttackEffe
 export function PREVENT_DAMAGE(store: StoreLike, state: State, effect: AttackEffect, source: Card): State {
   const damageEffect = preventDamageEffect(effect, source);
   return store.reduceEffect(state, damageEffect);
+}
+
+/**
+ * Checks if the a Pokemon is at full HP and that the damage dealt is enough to knock it out.
+ * TODO: This doesn't work if the an attack changes the result of a CheckHpEffect (e.g. discards an hp-modifying stadium)
+ */
+export function DAMAGED_FROM_FULL_HP(store: StoreLike, state: State, effect: PutDamageEffect, player: Player, target: PokemonCardList): boolean {
+  if (effect.target.damage != 0) {
+    return false;
+  }
+  const checkHpEffect = new CheckHpEffect(player, target);
+  store.reduceEffect(state, checkHpEffect);
+  return effect.damage >= checkHpEffect.hp;
 }
 
 /**

--- a/ptcg-server/src/sets/set-furious-fists/focus-sash.ts
+++ b/ptcg-server/src/sets/set-furious-fists/focus-sash.ts
@@ -1,14 +1,12 @@
 import { GameLog, PlayerType, StateUtils } from '../../game';
-import { TrainerType } from '../../game/store/card/card-types';
+import { CardType, TrainerType } from '../../game/store/card/card-types';
 import { TrainerCard } from '../../game/store/card/trainer-card';
 import { PutDamageEffect } from '../../game/store/effects/attack-effects';
-import { CheckHpEffect } from '../../game/store/effects/check-effects';
+import { CheckPokemonTypeEffect } from '../../game/store/effects/check-effects';
 import { Effect } from '../../game/store/effects/effect';
-import { IS_TOOL_BLOCKED } from '../../game/store/prefabs/prefabs';
+import { DAMAGED_FROM_FULL_HP, IS_TOOL_BLOCKED } from '../../game/store/prefabs/prefabs';
 
 import { State } from '../../game/store/state/state';
-import { StoreLike } from '../../game/store/store-like';
-
 export class FocusSash extends TrainerCard {
 
   public trainerType: TrainerType = TrainerType.TOOL;
@@ -26,34 +24,32 @@ export class FocusSash extends TrainerCard {
   public text: string =
     'If the [F] Pokémon this card is attached to has full HP and would be Knocked Out by damage from an opponent\'s attack, that Pokémon is not Knocked Out and its remaining HP becomes 10 instead. Then, discard this card.';
 
-  private canDiscard = false;
-
-  public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
-
-    if (effect instanceof PutDamageEffect && effect.target.tools.includes(this) && effect.target.damage == 0) {
+  public reduceEffect(store: any, state: State, effect: Effect): State {
+    if (effect instanceof PutDamageEffect && effect.target.tools.includes(this)) {
       const player = StateUtils.findOwner(state, effect.target);
 
-      if (IS_TOOL_BLOCKED(store, state, effect.player, this)) { return state; }
-
-      const checkHpEffect = new CheckHpEffect(player, effect.target);
-      store.reduceEffect(state, checkHpEffect);
-
-      if (effect.target.damage === 0 && effect.damage >= checkHpEffect.hp) {
-        effect.preventDefault = true;
-        effect.target.damage = checkHpEffect.hp - 10;
-        store.log(state, GameLog.LOG_PLAYER_PLAYS_TOOL, { card: this.name });
-        this.canDiscard = true;
+      if (
+        IS_TOOL_BLOCKED(store, state, player, this) ||
+        !DAMAGED_FROM_FULL_HP(store, state, effect, player, effect.target)) {
+        return state;
       }
 
-      if (this.canDiscard) {
-
-        player.forEachPokemon(PlayerType.BOTTOM_PLAYER, (cardList, card, index) => {
-          if (cardList.tools && cardList.tools.includes(this)) {
-            cardList.moveCardTo(this, player.discard);
-          }
-        });
+      const checkPokemonTypeEffect = new CheckPokemonTypeEffect(effect.target);
+      state = store.reduceEffect(state, checkPokemonTypeEffect);
+      if (!checkPokemonTypeEffect.cardTypes.includes(CardType.FIGHTING)) {
+        return state;
       }
+
+      effect.surviveOnTenHPReason = this.name;
+      store.log(state, GameLog.LOG_PLAYER_PLAYS_TOOL, { card: this.name });
+
+      player.forEachPokemon(PlayerType.BOTTOM_PLAYER, (cardList, card, index) => {
+        if (cardList.tools && cardList.tools.includes(this)) {
+          cardList.moveCardTo(this, player.discard);
+        }
+      });
     }
+
     return state;
   }
 }

--- a/ptcg-server/src/sets/set-stormfront/machamp-lv-x.ts
+++ b/ptcg-server/src/sets/set-stormfront/machamp-lv-x.ts
@@ -1,8 +1,8 @@
 import { GameError, GameMessage, PlayerType, PowerType, State, StateUtils, StoreLike } from '../../game';
 import { CardTag, CardType, Stage, SuperType } from '../../game/store/card/card-types';
 import { PokemonCard } from '../../game/store/card/pokemon-card';
-import { AbstractAttackEffect, DealDamageEffect, PutDamageEffect } from '../../game/store/effects/attack-effects';
-import { CheckHpEffect, CheckPokemonAttacksEffect, CheckPokemonPowersEffect, CheckTableStateEffect } from '../../game/store/effects/check-effects';
+import { DealDamageEffect, PutDamageEffect } from '../../game/store/effects/attack-effects';
+import { CheckPokemonAttacksEffect, CheckPokemonPowersEffect, CheckTableStateEffect } from '../../game/store/effects/check-effects';
 import { Effect } from '../../game/store/effects/effect';
 import { EndTurnEffect } from '../../game/store/effects/game-phase-effects';
 import { PlayPokemonEffect } from '../../game/store/effects/play-card-effects';
@@ -102,16 +102,11 @@ export class MachampLVX extends PokemonCard {
     }
 
     //Strong-Willed in effect
-    if (effect instanceof AbstractAttackEffect && effect instanceof PutDamageEffect
-      && HAS_MARKER(this.PREVENT_KNOCKED_OUT_DURING_OPPONENTS_NEXT_TURN_MARKER, effect.target, this)) {
-      const player = StateUtils.findOwner(state, effect.target);
-      const checkHpEffect = new CheckHpEffect(player, effect.target);
-      store.reduceEffect(state, checkHpEffect);
-
-      if (effect.damage >= (checkHpEffect.hp - player.active.damage)) {
-        effect.preventDefault = true;
-        effect.target.damage = checkHpEffect.hp - 10;
-      }
+    if (effect instanceof PutDamageEffect
+      && effect.target.cards.includes(this)
+      && HAS_MARKER(this.PREVENT_KNOCKED_OUT_DURING_OPPONENTS_NEXT_TURN_MARKER, effect.target, this)
+    ) {
+      effect.surviveOnTenHPReason = this.attacks[0].name;
       return state;
     }
 

--- a/ptcg-server/src/sets/set-supreme-victors/mr-mime.ts
+++ b/ptcg-server/src/sets/set-supreme-victors/mr-mime.ts
@@ -45,8 +45,7 @@ export class MrMime extends PokemonCard {
           return state;
         }
 
-        effect.preventDefault = true;
-        effect.target.damage = checkHpEffect.hp - 10;
+        effect.surviveOnTenHPReason = this.powers[0].name;
       }
     }
 


### PR DESCRIPTION
This PR changes the behavior of effects that cause a pokemon to survive on 10 hp when they should otherwise be KO'd. A pokemon now takes damage and then has its hp set to 10 with a message saying why. This allows for better logging.

The following cards are affected by this change
- Phanpy (Celestial Storm)
- Donphan (Lost Thunder)
- Machamp Level X (Stormfront)
- Mr Mime (Supreme Victors)
- Pikachu Ex (Surging Sparks)
- Focus Sash (Furious Fists)
- Survival Brace (Twilight Masquerade)

Focus Sash is also patched to work with fighting types only.

Bug with detecting whether a pokemon is damaged from full hp (described at https://discord.com/channels/1186678164517290105/1418622312218886226) is not yet resolved though