### PR TITLE
Conkeldurr V Counter patch

### DIFF
--- a/ptcg-server/src/sets/set-pokemon-go/conkeldurr-v.ts
+++ b/ptcg-server/src/sets/set-pokemon-go/conkeldurr-v.ts
@@ -50,7 +50,10 @@ export class ConkeldurrV extends PokemonCard {
 
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
     if (effect instanceof AttackEffect && effect.attack === this.attacks[0]) {
-      effect.damage += this.damageTakenLastTurn ?? 0;
+      const activeCard = effect.player.active.getPokemonCard();
+      if (activeCard !== undefined && activeCard.damageTakenLastTurn !== undefined) {
+        effect.damage += activeCard.damageTakenLastTurn;
+      }
     }
 
     if (effect instanceof AttackEffect && effect.attack === this.attacks[1]) {


### PR DESCRIPTION
References to "this" inside attackEffect handling don't work for copied attack such as Mime Jr's Mimed Games. This workaround uses the same workaround as Scovillain EX -- it's assumed that the pokemon in the active slot is the user of Counter whenever it is selected.