### PR TITLE
Damage reduction stacking

### DIFF
--- a/ptcg-server/src/game/store/effect-reducers/game-effect.ts
+++ b/ptcg-server/src/game/store/effect-reducers/game-effect.ts
@@ -125,10 +125,10 @@ function* useAttack(next: Function, store: StoreLike, state: State, effect: UseA
     yield store.prompt(state, new CoinFlipPrompt(
       player.id,
       GameMessage.FLIP_CONFUSION),
-      result => {
-        flip = result;
-        next();
-      });
+    result => {
+      flip = result;
+      next();
+    });
 
     if (flip === false) {
       store.log(state, GameLog.LOG_HURTS_ITSELF);

--- a/ptcg-server/src/game/store/effects/attack-effects.ts
+++ b/ptcg-server/src/game/store/effects/attack-effects.ts
@@ -70,15 +70,26 @@ export class PutDamageEffect extends AbstractAttackEffect implements Effect {
   readonly type: string = AttackEffects.PUT_DAMAGE_EFFECT;
   public preventDefault = false;
   public damage: number;
-  public damageReduced = false;
   public damageIncreased = true;
   public wasKnockedOutFromFullHP: boolean = false;
   public surviveOnTenHPReason: undefined | string = undefined;
   public weaknessApplied: boolean = false;
 
+  private nonstackingDamageReducers: string[] = [];
+
   constructor(base: AttackEffect, damage: number) {
     super(base);
     this.damage = damage;
+  }
+
+  reduceDamage(amount: number, source: string | undefined = undefined): void {
+    if (source && this.nonstackingDamageReducers.includes(source)) {
+      return;
+    }
+    this.damage = Math.max(0, this.damage - amount);
+    if (source) {
+      this.nonstackingDamageReducers.push(source);
+    }
   }
 }
 

--- a/ptcg-server/src/sets/set-breakpoint/reverse-valley.ts
+++ b/ptcg-server/src/sets/set-breakpoint/reverse-valley.ts
@@ -25,39 +25,41 @@ export class ReverseValley extends TrainerCard {
   public name: string = 'Reverse Valley';
 
   public fullName: string = 'Reverse Valley BKP';
-  
+
   public text: string =
     'Choose which way this card faces before you play it. The attacks of this â†“ player\'s [D] Pokémon do 10 more damage to your opponent\'s Active Pokémon (before applying Weakness and Resistance).' +
-    '' + 
+    '' +
     'Choose which way this card faces before you play it. Any damage done to this â†“ player\'s [M] Pokémon by an opponent\'s attack is reduced by 10 (after applying Weakness and Resistance).';
 
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
-    
+
     if (effect instanceof PlayStadiumEffect && effect.trainerCard === this) {
       const player = effect.player;
-      
+
       const options: { message: GameMessage, action: () => void }[] = [
         {
           message: GameMessage.UP,
-          action: () => {         const stadiumCard = StateUtils.getStadiumCard(state);
-            if (stadiumCard !== undefined ) {
+          action: () => {
+            const stadiumCard = StateUtils.getStadiumCard(state);
+            if (stadiumCard !== undefined) {
               const cardList = StateUtils.findCardList(state, stadiumCard);
               cardList.stadiumDirection = StadiumDirection.UP;
-              return state; 
+              return state;
             }
           }
         },
         {
           message: GameMessage.DOWN,
-          action: () => { const stadiumCard = StateUtils.getStadiumCard(state);
-            if (stadiumCard !== undefined ) {
+          action: () => {
+            const stadiumCard = StateUtils.getStadiumCard(state);
+            if (stadiumCard !== undefined) {
               const cardList = StateUtils.findCardList(state, stadiumCard);
-              cardList.stadiumDirection = StadiumDirection.DOWN; 
+              cardList.stadiumDirection = StadiumDirection.DOWN;
               return state;
             }
           }
         }];
-        
+
       return store.prompt(state, new SelectPrompt(
         player.id,
         GameMessage.WHICH_DIRECTION_TO_PLACE_STADIUM,
@@ -69,7 +71,7 @@ export class ReverseValley extends TrainerCard {
         if (option.action) {
           option.action();
         }
-        
+
         return state;
       });
     }
@@ -77,45 +79,43 @@ export class ReverseValley extends TrainerCard {
     if (effect instanceof PutDamageEffect && StateUtils.getStadiumCard(state) === this) {
       const stadiumCardList = StateUtils.findCardList(state, this);
       const owner = StateUtils.findOwner(state, stadiumCardList);
-      
+
       const checkDefenderType = new CheckPokemonTypeEffect(effect.target);
       store.reduceEffect(state, checkDefenderType);
-      
+
       // attacking against metal direction down
-      if (checkDefenderType.cardTypes.includes(CardType.METAL) && StadiumDirection.UP && 
-          owner !== effect.player) {
-        effect.damage = Math.max(0, effect.damage - 10);
-        effect.damageReduced = true;     
+      if (checkDefenderType.cardTypes.includes(CardType.METAL) && StadiumDirection.UP &&
+        owner !== effect.player) {
+        effect.reduceDamage(10);
       }
-      
-      if (checkDefenderType.cardTypes.includes(CardType.METAL) && StadiumDirection.DOWN && 
-          owner === effect.player) {
-        effect.damage = Math.max(0, effect.damage - 10);
-        effect.damageReduced = true;     
+
+      if (checkDefenderType.cardTypes.includes(CardType.METAL) && StadiumDirection.DOWN &&
+        owner === effect.player) {
+        effect.reduceDamage(10);
       }
     }
-    
+
     if (effect instanceof DealDamageEffect && StateUtils.getStadiumCard(state) === this) {
       const player = effect.player;
       const opponent = StateUtils.getOpponent(state, player);
 
       const stadiumCardList = StateUtils.findCardList(state, this);
       const owner = StateUtils.findOwner(state, stadiumCardList);
-      
+
       const checkPokemonType = new CheckPokemonTypeEffect(player.active);
       store.reduceEffect(state, checkPokemonType);
 
-      if (checkPokemonType.cardTypes.includes(CardType.DARK) && StadiumDirection.UP && 
-          effect.damage > 0 && effect.target === opponent.active && owner === effect.player) {
+      if (checkPokemonType.cardTypes.includes(CardType.DARK) && StadiumDirection.UP &&
+        effect.damage > 0 && effect.target === opponent.active && owner === effect.player) {
         effect.damage += 10;
       }
-      
+
       if (StadiumDirection.DOWN && owner !== player &&
-          checkPokemonType.cardTypes.includes(CardType.DARK) && effect.target === opponent.active) {
+        checkPokemonType.cardTypes.includes(CardType.DARK) && effect.target === opponent.active) {
         effect.damage += 10;
-      }      
+      }
     }
-    
+
     if (effect instanceof UseStadiumEffect && StateUtils.getStadiumCard(state) === this) {
       throw new GameError(GameMessage.CANNOT_USE_STADIUM);
     }

--- a/ptcg-server/src/sets/set-brilliant-stars/pot-helmet.ts
+++ b/ptcg-server/src/sets/set-brilliant-stars/pot-helmet.ts
@@ -38,14 +38,7 @@ export class PotHelmet extends TrainerCard {
         return state;
       }
 
-      if (effect.damageReduced) {
-        // Damage already reduced, don't reduce again
-        return state;
-      }
-
       const player = StateUtils.findOwner(state, effect.target);
-
-
 
       if (sourceCard && sourceCard.tags.includes(CardTag.POKEMON_V || CardTag.POKEMON_VMAX || CardTag.POKEMON_VSTAR || sourceCard.tags.includes(CardTag.POKEMON_ex || CardTag.RADIANT))) {
         return state;
@@ -54,8 +47,7 @@ export class PotHelmet extends TrainerCard {
       // Check if damage target is owned by this card's owner 
       const targetPlayer = StateUtils.findOwner(state, effect.target);
       if (targetPlayer === player) {
-        effect.damage = Math.max(0, effect.damage - 30);
-        effect.damageReduced = true;
+        effect.reduceDamage(30);
       }
 
       return state;

--- a/ptcg-server/src/sets/set-destined-rivals/stevens-carbink.ts
+++ b/ptcg-server/src/sets/set-destined-rivals/stevens-carbink.ts
@@ -3,7 +3,7 @@ import { CardTag, CardType, Stage } from '../../game/store/card/card-types';
 import { PutDamageEffect } from '../../game/store/effects/attack-effects';
 import { Effect } from '../../game/store/effects/effect';
 import { IS_ABILITY_BLOCKED } from '../../game/store/prefabs/prefabs';
-import { GamePhase, State } from '../../game/store/state/state';
+import { State } from '../../game/store/state/state';
 import { StoreLike } from '../../game/store/store-like';
 
 export class StevensCarbink extends PokemonCard {
@@ -44,18 +44,13 @@ export class StevensCarbink extends PokemonCard {
       const player = effect.player;
       const opponent = StateUtils.getOpponent(state, player);
 
-      if (effect.damageReduced || state.phase != GamePhase.ATTACK) {
-        return state;
-      }
-
       // Try to reduce PowerEffect, to check if something is blocking our ability
       if (IS_ABILITY_BLOCKED(store, state, opponent, this)) {
         return state;
       }
 
       if (effect.target.getPokemonCard()?.tags.includes(CardTag.STEVENS)) {
-        effect.damage = Math.max(0, effect.damage - 30);
-        effect.damageReduced = true;
+        effect.reduceDamage(30, this.powers[0].name);
       }
       return state;
     }

--- a/ptcg-server/src/sets/set-evolving-skies/full-face-guard.ts
+++ b/ptcg-server/src/sets/set-evolving-skies/full-face-guard.ts
@@ -45,8 +45,7 @@ export class FullFaceGuard extends TrainerCard {
         // Check if damage target is owned by this card's owner 
         const targetPlayer = StateUtils.findOwner(state, effect.target);
         if (targetPlayer === player) {
-          effect.damage = Math.max(0, effect.damage - 20);
-          effect.damageReduced = true;
+          effect.reduceDamage(20);
         }
 
         return state;

--- a/ptcg-server/src/sets/set-forbidden-light/metal-frying-pan.ts
+++ b/ptcg-server/src/sets/set-forbidden-light/metal-frying-pan.ts
@@ -45,8 +45,7 @@ export class MetalFryingPan extends TrainerCard {
       if (checkPokemonType.cardTypes.includes(CardType.METAL)) {
         // Allow damage
         effect.attackEffect.ignoreWeakness = true;
-        effect.damage = Math.max(0, effect.damage - 30);
-        effect.damageReduced = true;
+        effect.reduceDamage(30);
 
         const target = effect.target.getPokemonCard();
         if (target) {

--- a/ptcg-server/src/sets/set-fusion-strike/oricorio.ts
+++ b/ptcg-server/src/sets/set-fusion-strike/oricorio.ts
@@ -3,12 +3,11 @@ import { Stage, CardType, CardTag } from '../../game/store/card/card-types';
 import { StoreLike } from '../../game/store/store-like';
 import { State } from '../../game/store/state/state';
 import { Effect } from '../../game/store/effects/effect';
-import { PowerEffect } from '../../game/store/effects/game-effects';
 import { PutDamageEffect } from '../../game/store/effects/attack-effects';
 import { PowerType } from '../../game/store/card/pokemon-types';
 import { StateUtils } from '../../game/store/state-utils';
 import { PUT_X_DAMAGE_COUNTERS_IN_ANY_WAY_YOU_LIKE } from '../../game/store/prefabs/attack-effects';
-import { WAS_ATTACK_USED } from '../../game/store/prefabs/prefabs';
+import { IS_ABILITY_BLOCKED, WAS_ATTACK_USED } from '../../game/store/prefabs/prefabs';
 
 export class Oricorio extends PokemonCard {
 
@@ -63,24 +62,10 @@ export class Oricorio extends PokemonCard {
       const isTargetFusionStrike = target && target.tags.includes(CardTag.FUSION_STRIKE);
 
       if (isTargetFusionStrike) {
-
-        if (effect.damageReduced) {
+        if (IS_ABILITY_BLOCKED(store, state, player, this)) {
           return state;
         }
-
-        // Try to reduce PowerEffect, to check if something is blocking our ability
-        try {
-          const stub = new PowerEffect(player, {
-            name: 'test',
-            powerType: PowerType.ABILITY,
-            text: ''
-          }, this);
-          store.reduceEffect(state, stub);
-        } catch {
-          return state;
-        }
-        effect.damage -= 20;
-        effect.damageReduced = true;
+        effect.reduceDamage(20, this.powers[0].name);
       }
       return state;
     }

--- a/ptcg-server/src/sets/set-guardians-rising/aether-paradise-conservation-area.ts
+++ b/ptcg-server/src/sets/set-guardians-rising/aether-paradise-conservation-area.ts
@@ -23,23 +23,22 @@ export class AetherParadiseConvserationArea extends TrainerCard {
   public name: string = 'Aether Paradise Conservation Area';
 
   public fullName: string = 'Aether Paradise Conservation Area GRI';
-  
+
   public text: string =
     'Basic [G] Pokémon and Basic [L] Pokémon (both yours and your opponent\'s) take 30 less damage from the opponent\'s attacks (after applying Weakness and Resistance).';
 
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
-    
+
     if (effect instanceof PutDamageEffect && StateUtils.getStadiumCard(state) === this) {
       const checkPokemonType = new CheckPokemonTypeEffect(effect.target);
       store.reduceEffect(state, checkPokemonType);
-      
+
       if ((checkPokemonType.cardTypes.includes(CardType.GRASS) || checkPokemonType.cardTypes.includes(CardType.LIGHTNING)) &&
         effect.target.isStage(Stage.BASIC)) {
-        effect.damage = Math.max(0, effect.damage - 30);
-        effect.damageReduced = true;     
+        effect.reduceDamage(30);
       }
     }
-    
+
     if (effect instanceof UseStadiumEffect && StateUtils.getStadiumCard(state) === this) {
       throw new GameError(GameMessage.CANNOT_USE_STADIUM);
     }

--- a/ptcg-server/src/sets/set-paradox-rift/defiance-vest.ts
+++ b/ptcg-server/src/sets/set-paradox-rift/defiance-vest.ts
@@ -1,11 +1,11 @@
 import { TrainerCard } from '../../game/store/card/trainer-card';
 import { TrainerType } from '../../game/store/card/card-types';
 import { StoreLike } from '../../game/store/store-like';
-import { GamePhase, State } from '../../game/store/state/state';
+import { State } from '../../game/store/state/state';
 import { Effect } from '../../game/store/effects/effect';
 import { StateUtils } from '../../game';
 import { PutDamageEffect } from '../../game/store/effects/attack-effects';
-import { ToolEffect } from '../../game/store/effects/play-card-effects';
+import { IS_TOOL_BLOCKED } from '../../game/store/prefabs/prefabs';
 
 
 export class DefianceVest extends TrainerCard {
@@ -35,22 +35,7 @@ export class DefianceVest extends TrainerCard {
       const opponent = StateUtils.getOpponent(state, player);
 
       // Try to reduce ToolEffect, to check if something is blocking the tool from working
-      try {
-        const stub = new ToolEffect(effect.player, this);
-        store.reduceEffect(state, stub);
-      } catch {
-        return state;
-      }
-
-      // It's not an attack
-      if (state.phase !== GamePhase.ATTACK) {
-        return state;
-      }
-
-      if (effect.damageReduced) {
-        // Damage already reduced, don't reduce again
-        return state;
-      }
+      if (IS_TOOL_BLOCKED(store, state, effect.player, this)) { return state; }
 
       if (player.getPrizeLeft() <= opponent.getPrizeLeft()) {
         return state;
@@ -59,8 +44,7 @@ export class DefianceVest extends TrainerCard {
       // Check if damage target is owned by this card's owner 
       const targetPlayer = StateUtils.findOwner(state, effect.target);
       if (targetPlayer === player) {
-        effect.damage = Math.max(0, effect.damage - 40);
-        effect.damageReduced = true;
+        effect.reduceDamage(40);
       }
       return state;
     }

--- a/ptcg-server/src/sets/set-pokemon-151/rigid-band.ts
+++ b/ptcg-server/src/sets/set-pokemon-151/rigid-band.ts
@@ -41,20 +41,12 @@ export class RigidBand extends TrainerCard {
         return state;
       }
 
-      if (effect.damageReduced) {
-        // Damage already reduced, don't reduce again
-        return state;
-      }
-
       const player = StateUtils.findOwner(state, effect.target);
-
-
 
       // Check if damage target is owned by this card's owner 
       const targetPlayer = StateUtils.findOwner(state, effect.target);
       if (targetPlayer === player) {
-        effect.damage = Math.max(0, effect.damage - 30);
-        effect.damageReduced = true;
+        effect.reduceDamage(30);
       }
 
       return state;

--- a/ptcg-server/src/sets/set-primal-clash/shield-energy.ts
+++ b/ptcg-server/src/sets/set-primal-clash/shield-energy.ts
@@ -81,8 +81,7 @@ export class ShieldEnergy extends EnergyCard {
       store.reduceEffect(state, checkPokemonType);
 
       if (checkPokemonType.cardTypes.includes(CardType.METAL)) {
-        effect.damage = Math.max(0, effect.damage - 10);
-        effect.damageReduced = true;
+        effect.reduceDamage(10);
       }
     }
 

--- a/ptcg-server/src/sets/set-rebel-clash/aegislash.ts
+++ b/ptcg-server/src/sets/set-rebel-clash/aegislash.ts
@@ -1,4 +1,4 @@
-import { GamePhase, Power, PowerType, State, StateUtils, StoreLike } from '../../game';
+import { Power, PowerType, State, StateUtils, StoreLike } from '../../game';
 import { CardType, Stage } from '../../game/store/card/card-types';
 import { PokemonCard } from '../../game/store/card/pokemon-card';
 import { PutDamageEffect } from '../../game/store/effects/attack-effects';
@@ -51,10 +51,6 @@ export class Aegislash extends PokemonCard {
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
 
     if (effect instanceof PutDamageEffect) {
-      if (state.phase !== GamePhase.ATTACK) {
-        return state;
-      }
-
       const player = effect.player;
       const cardList = StateUtils.findCardList(state, this);
       const owner = StateUtils.findOwner(state, cardList);
@@ -74,8 +70,7 @@ export class Aegislash extends PokemonCard {
         return state;
       }
 
-      effect.damage = Math.max(0, effect.damage - 30);
-      effect.damageReduced = true;
+      effect.reduceDamage(30, this.powers[0].name);
     }
 
     return state;

--- a/ptcg-server/src/sets/set-scarlet-and-violet/rock-chestplate.ts
+++ b/ptcg-server/src/sets/set-scarlet-and-violet/rock-chestplate.ts
@@ -52,8 +52,7 @@ export class RockChestplate extends TrainerCard {
         // Check if damage target is owned by this card's owner 
         const targetPlayer = StateUtils.findOwner(state, effect.target);
         if (targetPlayer === player) {
-          effect.damage = Math.max(0, effect.damage - 30);
-          effect.damageReduced = true;
+          effect.reduceDamage(30);
         }
 
         return state;

--- a/ptcg-server/src/sets/set-silver-tempest/v-guard-energy.ts
+++ b/ptcg-server/src/sets/set-silver-tempest/v-guard-energy.ts
@@ -39,11 +39,6 @@ export class VGuardEnergy extends EnergyCard {
         return state;
       }
 
-      if (effect.damageReduced) {
-        // Damage already reduced, don't reduce again
-        return state;
-      }
-
       const player = StateUtils.findOwner(state, effect.target);
 
       if (IS_SPECIAL_ENERGY_BLOCKED(store, state, player, this, effect.target)) {
@@ -56,8 +51,7 @@ export class VGuardEnergy extends EnergyCard {
         // Check if damage target is owned by this card's owner 
         const targetPlayer = StateUtils.findOwner(state, effect.target);
         if (targetPlayer === player) {
-          effect.damage = Math.max(0, effect.damage - 30);
-          effect.damageReduced = true;
+          effect.reduceDamage(30, this.name);
         }
 
         return state;

--- a/ptcg-server/src/sets/set-stellar-crown/bouffalant.ts
+++ b/ptcg-server/src/sets/set-stellar-crown/bouffalant.ts
@@ -1,7 +1,7 @@
-import { PokemonCard, Stage, CardType, PowerType, StoreLike, State, GamePhase, PlayerType, StateUtils } from '../../game';
+import { PokemonCard, Stage, CardType, PowerType, StoreLike, State, PlayerType, StateUtils } from '../../game';
 import { PutDamageEffect } from '../../game/store/effects/attack-effects';
 import { Effect } from '../../game/store/effects/effect';
-import { PowerEffect } from '../../game/store/effects/game-effects';
+import { IS_ABILITY_BLOCKED } from '../../game/store/prefabs/prefabs';
 
 
 export class Bouffalant extends PokemonCard {
@@ -47,29 +47,13 @@ export class Bouffalant extends PokemonCard {
         return state;
       }
 
-      if (state.phase !== GamePhase.ATTACK) {
-        return state;
-      }
-
-      if (effect.damageReduced) {
-        return state;
-      }
-
-      try {
-        const stub = new PowerEffect(player, {
-          name: 'test',
-          powerType: PowerType.ABILITY,
-          text: ''
-        }, this);
-        store.reduceEffect(state, stub);
-      } catch {
+      if (IS_ABILITY_BLOCKED(store, state, player, this)) {
         return state;
       }
 
       const targetPokemon = effect.target.getPokemonCard();
       if (targetPokemon && targetPokemon.cardType === CardType.COLORLESS && targetPokemon.stage === Stage.BASIC && StateUtils.findOwner(state, effect.target) === player) {
-        effect.damage = Math.max(0, effect.damage - 60);
-        effect.damageReduced = true;
+        effect.reduceDamage(60, this.powers[0].name);
       }
     }
     return state;

--- a/ptcg-server/src/sets/set-team-up/metal-goggles.ts
+++ b/ptcg-server/src/sets/set-team-up/metal-goggles.ts
@@ -47,8 +47,7 @@ export class MetalGoggles extends TrainerCard {
           // Check if damage target is owned by this card's owner 
           const targetPlayer = StateUtils.findOwner(state, effect.target);
           if (targetPlayer === player) {
-            effect.damage = Math.max(0, effect.damage - 30);
-            effect.damageReduced = true;
+            effect.reduceDamage(30);
           }
 
           return state;

--- a/ptcg-server/src/sets/set-temporal-forces/full-metal-lab.ts
+++ b/ptcg-server/src/sets/set-temporal-forces/full-metal-lab.ts
@@ -36,8 +36,7 @@ export class FullMetalLab extends TrainerCard {
       store.reduceEffect(state, checkPokemonType);
 
       if (checkPokemonType.cardTypes.includes(CardType.METAL)) {
-        effect.damage = Math.max(0, effect.damage - 30);
-        effect.damageReduced = true;
+        effect.reduceDamage(30);
       }
     }
 

--- a/ptcg-server/src/sets/set-unbroken-bonds/metal-core-barrier.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/metal-core-barrier.ts
@@ -60,18 +60,12 @@ export class MetalCoreBarrier extends TrainerCard {
         return state;
       }
 
-      if (effect.damageReduced) {
-        // Damage already reduced, don't reduce again
-        return state;
-      }
-
       const player = StateUtils.findOwner(state, effect.target);
 
       // Check if damage target is owned by this card's owner 
       const targetPlayer = StateUtils.findOwner(state, effect.target);
       if (targetPlayer === player) {
-        effect.damage = Math.max(0, effect.damage - 70);
-        effect.damageReduced = true;
+        effect.reduceDamage(70);
       }
 
       return state;


### PR DESCRIPTION
Many damage reduction effects do not stack correctly.

In particular, the following cards should be able to stack but are not able to:
- Pot Helmet
- Defiance Vest
- Rigid Band
- Metal Core Barrier

This is especially relevant for strategies such as Revaroom EX which rely on stacking multiple damage-reducing tools.

The following cards should not be able to stack on themselves, but should be able to stack with other damage effects:
- VGuard Energy
- Steven's Carbink
- Oriciorio (Fusion Strike)
- Bouffalant (Stellar Crown)

Additionally Aegislash (Rebel Clash) incorrectly is allowed to stack with itself in the current implementation

The changes are fairly straightforward, so I doubt this should cause any issues -- but I can make a video demo if need be.

As an aside: judging from the current code I suspect a lot of these effects will apply for damage done to pokemon by a player's own attacks (such as Centiskorch SSP's Billowing Heat Wave) which may be relevant in Blissey/Centiskorch decks. I'll check if that is an actual issue and put out a patch if it is.