### PR TITLE
fix(cards): Fix Unbroken Bonds cards text/effects

### DIFF
--- a/ptcg-server/src/sets/set-unbroken-bonds/alolan-dugtrio.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/alolan-dugtrio.ts
@@ -22,7 +22,7 @@ export class AlolanDugtrio extends PokemonCard {
   public powers = [{
     name: 'Hair Wall',
     powerType: PowerType.ABILITY,
-    text: 'Your Metal Pokémon take 10 less damage from your opponent\'s attacks (after applying Weakness and Resistance).'
+    text: 'Your [M] Pokémon take 10 less damage from your opponent\'s attacks (after applying Weakness and Resistance).'
   }];
 
   public attacks = [

--- a/ptcg-server/src/sets/set-unbroken-bonds/aron.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/aron.ts
@@ -17,7 +17,7 @@ export class Aron extends PokemonCard {
     name: 'Rigidify',
     cost: [CardType.METAL],
     damage: 0,
-    text: 'During your opponent\'s next turn, this Pokémon takes 30 less damage from attacks(after applying Weakness and Resistance).'
+    text: 'During your opponent\'s next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance).'
   },
   {
     name: 'Metal Claw',

--- a/ptcg-server/src/sets/set-unbroken-bonds/blacephalon.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/blacephalon.ts
@@ -17,12 +17,12 @@ export class Blacephalon extends PokemonCard {
       cost: [R],
       damage: 10,
       damageCalculation: '+',
-      text: 'Turn 1 of your face-down Prize cards face up. If it\'s a [R] Energy card, this attack does 50 more damage. (That Prize card remains face up for the rest of the game.) '
+      text: 'Turn 1 of your face-down Prize cards face up. If it\'s a [R] Energy card, this attack does 50 more damage. (That Prize card remains face up for the rest of the game.)'
     },
     {
       name: 'Fireball Circus',
       cost: [R, R, R],
-      damage: 0,
+      damage: 50,
       damageCalculation: 'x',
       text: 'Discard any number of [R] Energy cards from your hand. This attack does 50 damage for each card you discarded in this way.'
     },
@@ -62,9 +62,9 @@ export class Blacephalon extends PokemonCard {
         GameMessage.CHOOSE_CARD_TO_DISCARD,
         player.hand,
         { superType: SuperType.ENERGY, name: 'Fire Energy' },
-        { min: 1, allowCancel: false }
+        { min: 0, allowCancel: false }
       ), selected => {
-        effect.damage += (50 * selected.length);
+        effect.damage = (50 * selected.length);
         player.hand.moveCardsTo(selected, player.discard);
       });
     }

--- a/ptcg-server/src/sets/set-unbroken-bonds/dedenne-gx.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/dedenne-gx.ts
@@ -19,8 +19,8 @@ export class DedenneGX extends PokemonCard {
   public powers = [{
     name: 'Dedechange',
     powerType: PowerType.ABILITY,
-    text: ' When you play this Pokémon from your hand onto your Bench during your turn,'
-      + ' you may discard your hand and draw 6 cards.You can\'t use more than 1 Dedechange Ability each turn.'
+    text: 'When you play this Pokémon from your hand onto your Bench during your turn,'
+      + ' you may discard your hand and draw 6 cards. You can\'t use more than 1 Dedechange Ability each turn.'
   }];
 
   public attacks = [{
@@ -34,7 +34,7 @@ export class DedenneGX extends PokemonCard {
     cost: [CardType.LIGHTNING, CardType.COLORLESS],
     damage: 50,
     text: 'Your opponent\'s Active Pokémon is now Paralyzed. Put this Pokémon and all cards attached to it into your hand.'
-      + ' (You can\'t use more than 1 GX attack in a game.) '
+      + ' (You can\'t use more than 1 GX attack in a game.)'
   }];
 
   public set = 'UNB';

--- a/ptcg-server/src/sets/set-unbroken-bonds/gardevoir-and-sylveon-gx.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/gardevoir-and-sylveon-gx.ts
@@ -22,20 +22,20 @@ export class GardevoirSylveonGX extends PokemonCard {
       name: 'Fairy Song',
       cost: [CardType.COLORLESS],
       damage: 0,
-      text: 'Search your deck for up to 2 [Y] Energy cards and attach them to your Benched Pokemon in any ' +
+      text: 'Search your deck for up to 2 [Y] Energy cards and attach them to your Benched Pokémon in any ' +
         'way you like. Then, shuffle your deck.'
     },
     {
       name: 'Kaleidostorm',
       cost: [CardType.FAIRY, CardType.FAIRY, CardType.COLORLESS],
       damage: 150,
-      text: 'Move any number of Energy from your Pokemon to your other Pokemon in any way you like.'
+      text: 'Move any number of Energy from your Pokémon to your other Pokémon in any way you like.'
     },
     {
       name: 'Magical Miracle-GX',
       cost: [CardType.FAIRY, CardType.FAIRY, CardType.FAIRY],
       damage: 200,
-      text: 'If this Pokemon has at least 3 extra [Y] Energy attached to it (in addition to this attack\'s cost), ' +
+      text: 'If this Pokémon has at least 3 extra [Y] Energy attached to it (in addition to this attack\'s cost), ' +
         'your opponent shuffles their hand into their deck. (You can\'t use more than 1 GX attack in a game.)'
     },
   ];

--- a/ptcg-server/src/sets/set-unbroken-bonds/gloom.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/gloom.ts
@@ -17,8 +17,8 @@ export class Gloom extends PokemonCard {
     name: 'Irresistible Aroma',
     useWhenInPlay: true,
     powerType: PowerType.ABILITY,
-    text: ' Once during your turn (before your attack), if your opponent\'s Bench isn\'t full, you may flip a coin.'
-      + 'If heads, your opponent reveals their hand.Put a Basic Pokémon you find there onto their Bench. '
+    text: 'Once during your turn (before your attack), if your opponent\'s Bench isn\'t full, you may flip a coin.'
+      + ' If heads, your opponent reveals their hand. Put a Basic Pokémon you find there onto their Bench.'
   }];
 
   public attacks = [{

--- a/ptcg-server/src/sets/set-unbroken-bonds/goldeen.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/goldeen.ts
@@ -15,7 +15,7 @@ export class Goldeen extends PokemonCard {
   public hp: number = 60;
 
   public weakness = [{ type: CardType.GRASS }];
-  public retreate = [CardType.COLORLESS];
+  public retreat = [CardType.COLORLESS];
 
   public attacks = [{
     name: 'Elegant Swim',

--- a/ptcg-server/src/sets/set-unbroken-bonds/golem.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/golem.ts
@@ -29,7 +29,7 @@ export class Golem extends PokemonCard {
       cost: [F, C, C, C],
       damage: 180,
       damageCalculation: '-',
-      text: 'This attack does 20 less damage for each Colorless in your opponent\'s Active Pokémon\'s Retreat Cost.'
+      text: 'This attack does 20 less damage for each [C] in your opponent\'s Active Pokémon\'s Retreat Cost.'
     }
   ];
 

--- a/ptcg-server/src/sets/set-unbroken-bonds/grubbin.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/grubbin.ts
@@ -20,7 +20,7 @@ export class Grubbin extends PokemonCard {
       name: 'Electrical Signal',
       cost: [C],
       damage: 0,
-      text: 'Search your deck for up to 2 Lightning Pokémon, reveal them, and put them into your hand. Then, shuffle your deck.'
+      text: 'Search your deck for up to 2 [L] Pokémon, reveal them, and put them into your hand. Then, shuffle your deck.'
     },
     {
       name: 'Corkscrew Punch',

--- a/ptcg-server/src/sets/set-unbroken-bonds/kartana.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/kartana.ts
@@ -23,7 +23,7 @@ export class Kartana extends PokemonCard {
     name: 'False Swipe',
     cost: [CardType.GRASS, CardType.COLORLESS, CardType.COLORLESS],
     damage: 0,
-    text: ' Flip a coin. If heads, put damage counters on your opponent\'s Active Pokémon until its remaining HP is 10. '
+    text: 'Flip a coin. If heads, put damage counters on your opponent\'s Active Pokémon until its remaining HP is 10.'
   }];
 
   public set: string = 'UNB';

--- a/ptcg-server/src/sets/set-unbroken-bonds/krookodile.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/krookodile.ts
@@ -25,7 +25,7 @@ export class Krookodile extends PokemonCard {
       cost: [C, C, C],
       damage: 50,
       damageCalculation: 'x',
-      text: 'This attack does 50 damage for each Colorless in your opponent\'s Active Pokémon\'s Retreat Cost.'
+      text: 'This attack does 50 damage for each [C] in your opponent\'s Active Pokémon\'s Retreat Cost.'
     },
     {
       name: 'Crunch',

--- a/ptcg-server/src/sets/set-unbroken-bonds/lairon.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/lairon.ts
@@ -18,7 +18,7 @@ export class Lairon extends PokemonCard {
     name: 'Rigidify',
     cost: [CardType.METAL],
     damage: 0,
-    text: 'During your opponent\'s next turn, this Pokémon takes 30 less damage from attacks(after applying Weakness and Resistance).'
+    text: 'During your opponent\'s next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance).'
   },
   {
     name: 'Headbutt',

--- a/ptcg-server/src/sets/set-unbroken-bonds/lickitung.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/lickitung.ts
@@ -17,7 +17,7 @@ export class Lickitung extends PokemonCard {
     name: 'Lick',
     cost: [CardType.COLORLESS, CardType.COLORLESS],
     damage: 30,
-    text: ' Flip a coin. If heads, your opponent\'s Active Pokémon is now Paralyzed.'
+    text: 'Flip a coin. If heads, your opponent\'s Active Pokémon is now Paralyzed.'
   }];
 
   public set = 'UNB';

--- a/ptcg-server/src/sets/set-unbroken-bonds/melmetal.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/melmetal.ts
@@ -26,7 +26,7 @@ export class Melmetal extends PokemonCard {
     name: 'Metal Eater',
     useWhenInPlay: true,
     powerType: PowerType.ABILITY,
-    text: 'Once during your turn (before your attack), you may discard a Metal Pokémon from your hand. If you do, heal 100 damage from this Pokémon.'
+    text: 'Once during your turn (before your attack), you may discard a [M] Pokémon from your hand. If you do, heal 100 damage from this Pokémon.'
   }];
 
   public attacks = [

--- a/ptcg-server/src/sets/set-unbroken-bonds/meltan.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/meltan.ts
@@ -23,7 +23,7 @@ export class Meltan extends PokemonCard {
       cost: [M],
       damage: 10,
       damageCalculation: '+',
-      text: 'If your opponent\'s Active Pokémon is a Metal Pokémon, this attack does 40 more damage.'
+      text: 'If your opponent\'s Active Pokémon is a [M] Pokémon, this attack does 40 more damage.'
     }
   ];
 

--- a/ptcg-server/src/sets/set-unbroken-bonds/meowstic.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/meowstic.ts
@@ -33,7 +33,7 @@ export class Meowstic extends PokemonCard {
       name: 'Perplexing Eyes',
       cost: [P, C, C],
       damage: 70,
-      text: 'The Defending Pokémon\'s Weakness is now Psychic until the end of your next turn. (The amount of Weakness doesn\'t change.)'
+      text: 'The Defending Pokémon\'s Weakness is now [P] until the end of your next turn. (The amount of Weakness doesn\'t change.)'
     }
   ];
 

--- a/ptcg-server/src/sets/set-unbroken-bonds/meowth.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/meowth.ts
@@ -20,7 +20,7 @@ export class Meowth extends PokemonCard {
     text: 'Draw 2 cards. If you do, this Pokémon is now Asleep.'
   },
   {
-    name: 'Tail Whip',
+    name: 'Tail Whap',
     cost: [CardType.COLORLESS, CardType.COLORLESS],
     damage: 30,
     text: ''
@@ -37,11 +37,15 @@ export class Meowth extends PokemonCard {
     if (WAS_ATTACK_USED(effect, 0, this)) {
       const player = effect.player;
 
+      const before = player.hand.cards.length;
       player.deck.moveTo(player.hand, 2);
 
-      const specialConditionEffect = new AddSpecialConditionsEffect(effect, [SpecialCondition.ASLEEP]);
-      specialConditionEffect.target = player.active;
-      store.reduceEffect(state, specialConditionEffect);
+      // "If you do" — only fall asleep if at least one card was actually drawn.
+      if (player.hand.cards.length > before) {
+        const specialConditionEffect = new AddSpecialConditionsEffect(effect, [SpecialCondition.ASLEEP]);
+        specialConditionEffect.target = player.active;
+        store.reduceEffect(state, specialConditionEffect);
+      }
     }
 
     return state;

--- a/ptcg-server/src/sets/set-unbroken-bonds/mismagius.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/mismagius.ts
@@ -26,7 +26,7 @@ export class Mismagius extends PokemonCard {
     name: 'Hypnoblast',
     cost: [CardType.PSYCHIC, CardType.COLORLESS, CardType.COLORLESS],
     damage: 70,
-    text: 'Your opponent\'s Active Pokemon is now Asleep.'
+    text: 'Your opponent\'s Active Pokémon is now Asleep.'
   }];
 
   public set: string = 'UNB';

--- a/ptcg-server/src/sets/set-unbroken-bonds/muk-and-alolan-muk-gx.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/muk-and-alolan-muk-gx.ts
@@ -21,7 +21,7 @@ export class MukAlolanMukGX extends PokemonCard {
       text: 'Your opponent\'s Active Pokémon is now Poisoned. Put 8 damage counters instead of 1 on that Pokémon between turns.'
     },
     {
-      name: 'Posion Absorption',
+      name: 'Poison Absorption',
       cost: [P, C, C, C],
       damage: 120,
       text: 'If your opponent\'s Active Pokémon is Poisoned, heal 100 damage from this Pokémon.'

--- a/ptcg-server/src/sets/set-unbroken-bonds/murkrow.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/murkrow.ts
@@ -16,7 +16,7 @@ export class Murkrow extends PokemonCard {
   public attacks = [
     {
       name: 'Astonish',
-      cost: [C],
+      cost: [D],
       damage: 0,
       text: 'Choose a random card from your opponent\'s hand. Your opponent reveals that card and shuffles it into their deck.'
     }

--- a/ptcg-server/src/sets/set-unbroken-bonds/porygon.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/porygon.ts
@@ -15,7 +15,7 @@ export class Porygon extends PokemonCard {
 
   public weakness = [{ type: CardType.FIGHTING }];
 
-  public retreat = [];
+  public retreat = [CardType.COLORLESS];
 
   public attacks = [{
     name: 'Quick Draw',

--- a/ptcg-server/src/sets/set-unbroken-bonds/reshiram-and-charizard-gx.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/reshiram-and-charizard-gx.ts
@@ -19,13 +19,13 @@ export class ReshiramCharizardGX extends PokemonCard {
     cost: [R, C],
     damage: 30,
     damageCalculation: '+',
-    text: 'This attack does 10 more damage for each damage counter on this Pokemon.'
+    text: 'This attack does 10 more damage for each damage counter on this Pokémon.'
   },
   {
     name: 'Flare Strike',
     cost: [R, R, R, C],
     damage: 230,
-    text: 'This Pokemon can\'t use Flare Strike during your next turn.'
+    text: 'This Pokémon can\'t use Flare Strike during your next turn.'
   },
   {
     name: 'Double Blaze-GX',
@@ -34,9 +34,9 @@ export class ReshiramCharizardGX extends PokemonCard {
     shredAttack: false,
     gxAttack: true,
     damageCalculation: '+',
-    text: 'If this Pokemon has at least 3 extra [R] Energy attached to it (in addition to this attack\'s cost), ' +
+    text: 'If this Pokémon has at least 3 extra [R] Energy attached to it (in addition to this attack\'s cost), ' +
       'this attack does 100 more damage, and this attack\'s damage isn\'t affected by any effects on your ' +
-      'opponent\'s Active Pokemon. (You can\'t use more than 1 GX attack in a game.)'
+      'opponent\'s Active Pokémon. (You can\'t use more than 1 GX attack in a game.)'
   },];
 
   public set = 'UNB';

--- a/ptcg-server/src/sets/set-unbroken-bonds/slowbro.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/slowbro.ts
@@ -23,7 +23,7 @@ export class Slowbro extends PokemonCard {
     {
       name: 'Yawn',
       cost: [W],
-      damage: 20,
+      damage: 0,
       text: 'Your opponent\'s Active Pokémon is now Asleep.'
     },
     {

--- a/ptcg-server/src/sets/set-unbroken-bonds/togekiss.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/togekiss.ts
@@ -25,7 +25,7 @@ export class Togekiss extends PokemonCard {
     name: 'Fairy Feast',
     useWhenInPlay: true,
     powerType: PowerType.ABILITY,
-    text: 'Once during your turn (before your attack), you may heal 30 damage from each of your Fairy Pokémon.'
+    text: 'Once during your turn (before your attack), you may heal 30 damage from each of your [Y] Pokémon.'
   }];
 
   public attacks = [

--- a/ptcg-server/src/sets/set-unbroken-bonds/venomoth.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/venomoth.ts
@@ -1,6 +1,5 @@
-import { GameError, GameMessage, PokemonCard, Stage, State, StateUtils, StoreLike } from '../../game';
+import { GameError, GameMessage, PokemonCard, Stage, State, StoreLike } from '../../game';
 import { Effect } from '../../game/store/effects/effect';
-import { AfterAttackEffect } from '../../game/store/effects/game-phase-effects';
 import { THIS_ATTACK_DOES_X_DAMAGE_TO_1_OF_YOUR_OPPONENTS_BENCHED_POKEMON } from '../../game/store/prefabs/attack-effects';
 import { ADD_POISON_TO_PLAYER_ACTIVE, WAS_ATTACK_USED } from '../../game/store/prefabs/prefabs';
 
@@ -19,10 +18,10 @@ export class Venomoth extends PokemonCard {
     text: 'You can use this attack only if your opponent\'s Active Pokémon is affected by a Special Condition. This attack does 90 damage to 1 of your opponent\'s Benched Pokémon. (Don\'t apply Weakness and Resistance for Benched Pokémon.)'
   },
   {
-    name: 'Poision Powder',
+    name: 'Poison Powder',
     cost: [G],
     damage: 30,
-    text: ''
+    text: 'Your opponent\'s Active Pokémon is now Poisoned.'
   }];
 
   public set = 'UNB';
@@ -30,8 +29,6 @@ export class Venomoth extends PokemonCard {
   public cardImage: string = 'assets/cardback.png';
   public name: string = 'Venomoth';
   public fullName = 'Venomoth UNB';
-
-  public usedPoisonPowder = false;
 
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
 
@@ -44,12 +41,7 @@ export class Venomoth extends PokemonCard {
     }
 
     if (WAS_ATTACK_USED(effect, 1, this)) {
-      this.usedPoisonPowder = true;
-    }
-
-    if (effect instanceof AfterAttackEffect && this.usedPoisonPowder === true) {
-      this.usedPoisonPowder = false;
-      ADD_POISON_TO_PLAYER_ACTIVE(store, state, StateUtils.getOpponent(state, effect.player), this);
+      ADD_POISON_TO_PLAYER_ACTIVE(store, state, effect.opponent, this);
     }
 
     return state;

--- a/ptcg-server/src/sets/set-unbroken-bonds/zeraora.ts
+++ b/ptcg-server/src/sets/set-unbroken-bonds/zeraora.ts
@@ -25,7 +25,7 @@ export class Zeraora extends PokemonCard {
     name: 'Discharge',
     cost: [CardType.LIGHTNING, CardType.COLORLESS, CardType.COLORLESS],
     damage: 50,
-    text: 'Discard all [L] Energy from this Pokémon. This attack does 50 damage for each card you discarded in this way. '
+    text: 'Discard all [L] Energy from this Pokémon. This attack does 50 damage for each card you discarded in this way.'
   }];
 
   public set: string = 'UNB';


### PR DESCRIPTION
# Fix Unbroken Bonds cards — printed data, attack behavior, and text

Brings Unbroken Bonds card classes into agreement with the printed cards, surfaced by a cross-check of
each class against pokemontcg.io and the independent limitlesstcg reference. Three layers: corrected
**printed data**, fixed **attack behavior**, and standardized **rules text**.

## 1. Printed data

Card image included for each change (click a thumbnail for the full-size card); the printed values are
visible on the cards.

| Card | # | Field | Before | After |
|---|---|---|---|---|
| <a href="https://images.pokemontcg.io/sm10/61_hires.png"><img src="https://images.pokemontcg.io/sm10/61.png" width="120"></a> | Muk & Alolan Muk-GX — `#61`, `#196`, `#197`, `#220` | 2nd attack name | `Posion Absorption` | **`Poison Absorption`** |
| <a href="https://images.pokemontcg.io/sm10/11_hires.png"><img src="https://images.pokemontcg.io/sm10/11.png" width="120"></a> | Venomoth — `#11` | 2nd attack name | `Poision Powder` | **`Poison Powder`** |
| <a href="https://images.pokemontcg.io/sm10/147_hires.png"><img src="https://images.pokemontcg.io/sm10/147.png" width="120"></a> | Meowth — `#147` | 2nd attack name | `Tail Whip` | **`Tail Whap`** |
| <a href="https://images.pokemontcg.io/sm10/108_hires.png"><img src="https://images.pokemontcg.io/sm10/108.png" width="120"></a> | Murkrow — `#108` | "Astonish" cost | `Colorless` | **`Darkness`** |
| <a href="https://images.pokemontcg.io/sm10/48_hires.png"><img src="https://images.pokemontcg.io/sm10/48.png" width="120"></a> | Goldeen — `#48` | retreat cost | `0` | **`1`** |
| <a href="https://images.pokemontcg.io/sm10/155_hires.png"><img src="https://images.pokemontcg.io/sm10/155.png" width="120"></a> | Porygon — `#155` | retreat cost | `0` | **`1`** |
| <a href="https://images.pokemontcg.io/sm10/32_hires.png"><img src="https://images.pokemontcg.io/sm10/32.png" width="120"></a> | Blacephalon — `#32` | "Fireball Circus" damage | `0` | **`50`** ¹ |
| <a href="https://images.pokemontcg.io/sm10/43_hires.png"><img src="https://images.pokemontcg.io/sm10/43.png" width="120"></a> | Slowbro — `#43` | "Yawn" damage | `20` | **`0`** ² |

¹ **Blacephalon** — the card prints `50×` (50 damage per Fire Energy discarded); the base `damage` field becomes `50`. See the matching effect-logic change in §2.
² **Slowbro** — "Yawn" is effect-only (puts the Defending Pokémon to Sleep) and prints **no** damage; the existing `20` was simply wrong. (The `100×` on this card belongs to its other attack, "Three Strikes".)

Note: **Goldeen**'s retreat was silently `0` because the property was misspelled `retreate`; the fix renames it to `retreat` (the value `[Colorless]` was already correct).

## 2. Attack behavior

- **Blacephalon (`#32`) — "Fireball Circus":** discards **any number** of Fire Energy → prompt `min: 1 → 0` (a player with none can now use it for 0). With the base damage now `50`, the effect logic is **assigned** (`=`) rather than **added** (`+=`), so the `50×` total isn't double-counted.
- **Meowth (`#147`) — "Caturday":** only falls Asleep **if a card was actually drawn** ("if you do") — no longer self-inflicts Asleep on an empty deck.
- **Venomoth (`#11`) — "Poison Powder":** Poisons the Defending Pokémon **directly in the attack** (replacing a fragile `AfterAttackEffect` flag) and carries its printed text.

## 3. Text standardization

- **Accents** `Pokemon` → `Pokémon`: Gardevoir & Sylveon-GX, Reshiram & Charizard-GX, Mismagius
- **Inline energy → the `[X]` standard:** Alolan Dugtrio / Melmetal / Meltan `Metal`→`[M]`, Golem / Krookodile `Colorless`→`[C]`, Grubbin `Lightning`→`[L]`, Meowstic `Psychic`→`[P]`, Togekiss `Fairy`→`[Y]`
- **Whitespace** — stray leading/trailing spaces and missing spaces (`attacks(after`→`attacks (after`, `coin.If`→`coin. If`, `cards.You`→`cards. You`): Aron, Lairon, Gloom, Dedenne-GX, Blacephalon, Kartana, Lickitung, Zeraora

## 4. Verification

**All 7 behavioral changes verified working.**

| Card | Fix | Scenario | Result |
|---|---|---|---|
| **Goldeen** | `retreate`→`retreat` typo (was free retreat) | retreat with 0 energy | ✅ `INSUFFICIENT_ENERGY`; retreatable with 1 energy |
| **Porygon** | retreat `[]`→`[C]` | retreat with 0 energy | ✅ `INSUFFICIENT_ENERGY` |
| **Murkrow** | Astonish cost `[C]`→`[D]` | attack with Water vs Darkness energy | ✅ Water(C) → `INSUFFICIENT_ENERGY`; Darkness(D) → legal |
| **Meowth** | Caturday: Asleep only *if* a card was drawn | attack with deck vs empty deck | ✅ deck → drew 2 + Asleep; empty deck → drew 0, **not** Asleep |
| **Venomoth** | Poison Powder now Poisons opp. Active | attack | ✅ opponent Poisoned, 30 attack damage |
| **Slowbro** | Yawn damage `20`→`0` | attack | ✅ 0 damage + opponent Asleep |
| **Blacephalon** | Fireball Circus: base 50, min 0, `=` (was `+=`) | discard 0 / 1 / 2 Fire | ✅ 0 / 50 / 100 damage (`50 × discarded`); discard-0 whiff now allowed |

## Not changed — `fullName` left as-is (by project policy)

The Muk & Alolan Muk-GX class has a copy-paste leftover in its `fullName` (`'Umbreon & Darkrai-GX UNB'`).
The card's `name` is correct (`'Muk & Alolan Muk-GX'`); only `fullName` is off. **It is deliberately NOT
touched here:** per the project README, `fullName` is a stable database key — "NEVER change the fullName
property of an existing card. This property is stored throughout the database." Changing it would orphan
stored references, so it stays frozen. Noted only for awareness.
