### PR TITLE
Fix typo in existing tyrantrum logging code.

### DIFF
--- a/ptcg-server/src/sets/11-mega-evolution/set-perfect-order/tyrantrum.ts
+++ b/ptcg-server/src/sets/11-mega-evolution/set-perfect-order/tyrantrum.ts
@@ -72,7 +72,7 @@ export class Tyrantrum extends PokemonCard {
             const deckTop = new CardList();
             opponent.deck.moveTo(deckTop, 1);
             if (deckTop.cards.length > 0) {
-              store.log(s, GameLog.LOG_PLAYER_DISCARDS_CARD, { name: opponent.name, card: deckTop.cards[0].name, effect: 'Wreak Havoc' });
+              store.log(s, GameLog.LOG_PLAYER_DISCARDS_CARD, { name: opponent.name, card: deckTop.cards[0].name, effectName: 'Wreak Havoc' });
               deckTop.moveTo(opponent.discard);
             }
             // Continue flipping


### PR DESCRIPTION
`effectName` mislabeled as `effect`.

Found  while using the card as a implementation reference.