### PR TITLE
Fix kartana missing ULTRA BEAST label

### DIFF
--- a/ptcg-server/src/sets/08-sun-and-moon/set-unbroken-bonds/kartana.ts
+++ b/ptcg-server/src/sets/08-sun-and-moon/set-unbroken-bonds/kartana.ts
@@ -8,6 +8,7 @@ import { PutDamageEffect } from '../../../game/store/effects/attack-effects';
 import { WAS_ATTACK_USED, COIN_FLIP_PROMPT } from '../../../game/store/prefabs/prefabs';
 
 export class Kartana extends PokemonCard {
+  protected _tags = [CardTag.ULTRA_BEAST];
   public stage: Stage = Stage.BASIC;
   public cardType: CardType[] = [G];
   public hp: number = 70;


### PR DESCRIPTION
Adds ultra beast label to the card, which was the only ultra beast in unbroken bonds lacking the label.

Found  while using the card as a implementation reference.